### PR TITLE
Prevent app switcher from taking screenshots of EntryActivity, EntryEditActivity

### DIFF
--- a/src/keepass2android/EntryActivity.cs
+++ b/src/keepass2android/EntryActivity.cs
@@ -321,7 +321,10 @@ namespace keepass2android
 			_activityDesign.ApplyTheme(); 
 			base.OnCreate(savedInstanceState);
 			
-
+			if (prefs.GetBoolean(GetString(Resource.String.ViewDatabaseSecure_key), true))
+			{
+				Window.SetFlags(WindowManagerFlags.Secure, WindowManagerFlags.Secure);
+			}
 			
 
 			SetEntryView();

--- a/src/keepass2android/EntryEditActivity.cs
+++ b/src/keepass2android/EntryEditActivity.cs
@@ -91,6 +91,12 @@ namespace keepass2android
 		protected override void OnCreate(Bundle savedInstanceState)
 		{
 			base.OnCreate(savedInstanceState);
+
+			if (PreferenceManager.GetDefaultSharedPreferences(this).GetBoolean
+					(GetString(Resource.String.ViewDatabaseSecure_key), true))
+			{
+				Window.SetFlags(WindowManagerFlags.Secure, WindowManagerFlags.Secure);
+			}
 			
 			if (LastNonConfigurationInstance != null)
 			{


### PR DESCRIPTION
Currently, it's possible for the OS to take a screenshot of the entry activity for the app switcher if the user leaves the app while using it, potentially exposing the user's passwords if they have decided to show any passwords in cleartext. Adapted my code from [fc832dd3](https://github.com/PhilippC/keepass2android/commit/fc832dd3dc019e28dc36a8c76747220e90dc4358).