### PR TITLE
Replace YubiChallenge with ykDroid

### DIFF
--- a/src/keepass2android/ChallengeXCKey.cs
+++ b/src/keepass2android/ChallengeXCKey.cs
@@ -33,7 +33,7 @@ namespace keepass2android
                             }
 
                         }
-                        var chalIntent = Activity.TryGetYubichallengeIntentOrPrompt(challenge64, true);
+                        var chalIntent = Activity.TryGetYubiKeyChallengeResponseIntentOrPrompt(challenge64, true);
 
                         if (chalIntent == null)
                             throw new Exception("YubiChallenge not installed.");

--- a/src/keepass2android/LockingActivity.cs
+++ b/src/keepass2android/LockingActivity.cs
@@ -123,13 +123,22 @@ namespace keepass2android
 	    }
 
 
-	    public Intent TryGetYubichallengeIntentOrPrompt(byte[] challenge, bool promptToInstall)
+	    public Intent TryGetYubiKeyChallengeResponseIntentOrPrompt(byte[] challenge, bool promptToInstall)
 	    {
-	        Intent chalIntent = new Intent("com.yubichallenge.NFCActivity.CHALLENGE");
+	        Intent chalIntent = new Intent("net.pp3345.ykdroid.intent.action.CHALLENGE_RESPONSE");
 	        chalIntent.PutExtra("challenge", challenge);
-	        chalIntent.PutExtra("slot", 2);
 	        IList<ResolveInfo> activities = PackageManager.QueryIntentActivities(chalIntent, 0);
 	        bool isIntentSafe = activities.Count > 0;
+	        if (isIntentSafe)
+	        {
+	            return chalIntent;
+	        }
+
+	        chalIntent = new Intent("com.yubichallenge.NFCActivity.CHALLENGE");
+	        chalIntent.PutExtra("challenge", challenge);
+	        chalIntent.PutExtra("slot", 2);
+	        activities = PackageManager.QueryIntentActivities(chalIntent, 0);
+	        isIntentSafe = activities.Count > 0;
 	        if (isIntentSafe)
 	        {
 	            return chalIntent;
@@ -137,9 +146,9 @@ namespace keepass2android
 	        if (promptToInstall)
 	        {
 	            AlertDialog.Builder b = new AlertDialog.Builder(this);
-	            b.SetMessage(Resource.String.YubiChallengeNotInstalled);
+	            b.SetMessage(Resource.String.ykDroidNotInstalled);
 	            b.SetPositiveButton(Android.Resource.String.Ok,
-	                delegate { Util.GotoUrl(this, GetString(Resource.String.MarketURL) + "com.yubichallenge"); });
+	                delegate { Util.GotoUrl(this, GetString(Resource.String.MarketURL) + "net.pp3345.ykdroid"); });
 	            b.SetNegativeButton(Resource.String.cancel, delegate { });
 	            b.Create().Show();
 	        }

--- a/src/keepass2android/PasswordActivity.cs
+++ b/src/keepass2android/PasswordActivity.cs
@@ -625,7 +625,7 @@ namespace keepass2android
 
 			protected override void HandleSuccess()
 			{
-			    var chalIntent = Activity.TryGetYubichallengeIntentOrPrompt(Activity._chalInfo.Challenge, true);
+			    var chalIntent = Activity.TryGetYubiKeyChallengeResponseIntentOrPrompt(Activity._chalInfo.Challenge, true);
 
                 if (chalIntent != null)
 			    {

--- a/src/keepass2android/Properties/AndroidManifest_debug.xml
+++ b/src/keepass2android/Properties/AndroidManifest_debug.xml
@@ -58,7 +58,7 @@
             </intent-filter>
         </activity>
 		
-		<activity android:configChanges="orientation" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
 			<intent-filter android:label="@string/app_name">
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Properties/AndroidManifest_light.xml
+++ b/src/keepass2android/Properties/AndroidManifest_light.xml
@@ -11,7 +11,7 @@
 				<category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 		</activity>
-		<activity android:configChanges="keyboardHidden|orientation" android:label="@string/app_name" android:theme="@style/MyTheme" android:name="keepass2android.PasswordActivity">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme" android:name="keepass2android.PasswordActivity">
 			<intent-filter android:label="@string/app_name">
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Properties/AndroidManifest_net.xml
+++ b/src/keepass2android/Properties/AndroidManifest_net.xml
@@ -59,7 +59,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-		<activity android:configChanges="orientation" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
       <intent-filter android:label="@string/app_name">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Properties/AndroidManifest_nonet.xml
+++ b/src/keepass2android/Properties/AndroidManifest_nonet.xml
@@ -43,7 +43,7 @@
             </intent-filter>
         </activity>
  
-		<activity android:configChanges="orientation" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity" android:windowSoftInputMode="adjustResize">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity" android:windowSoftInputMode="adjustResize">
       <intent-filter android:label="@string/app_name">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Resources/values-ar/strings.xml
+++ b/src/keepass2android/Resources/values-ar/strings.xml
@@ -453,7 +453,6 @@
   <string name="init_otp">تحميل الملف الخارجي الخاص بكلمة المرور لمرة واحدة OTP&#8230;</string>
   <string name="otp_explanation">(12345) emad.</string>
   <string name="otp_hint">كلمة مرور مؤقتة %1$d</string>
-  <string name="YubiChallengeNotInstalled">تعذر العثور على تطبيق يمكنه التعامل مع هذا التحدي. يرجى تثبيت تطبيق يوبيتشالينج Yubichallenge من متجر  Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">تعذر تحميل الملف الخارجي الخاص ب \"كلمة المرور لمرة واحدة\"  OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">الرجاء استخدام ألأضافة \"أوتبكييبروف\" OtpKeyProv في  KeePass 2.x (نسخة PC) لتمكين قاعدة بياناتك مناستخدام \"كلمة المرور لمرة واحدة\" OTP !</string>
   <string name="otp_discarded_because_no_db">الرجاء تحديد قاعدة البيانات أولاً. سيتم تجاهل كلمة المرور لمرة واحدة لدواعي ألأمان.</string>

--- a/src/keepass2android/Resources/values-ca/strings.xml
+++ b/src/keepass2android/Resources/values-ca/strings.xml
@@ -459,7 +459,6 @@ Això emmagatzemarà la contrasenya mestra d\'aquest
   <string name="init_otp">Càrrega arxiu OTP auxiliar&#8230;</string>
   <string name="otp_explanation">Introduïu la següent Contrasenya-d\'un-sol-us (One-time-passwords OTPs). Llisca la teva Yubikey NEO al darrere el seu dispositiu per entrar mitjançant NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">No puc trobar un aplicació que pugui manegar el desafiament. Si us plau instal·la Yubichallenge del Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">No s\'ha pogut carregar el fitxer OTP auxiliar!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Si us plau, utilitzeu el connector OtpKeyProv de KeePass 2. x (PC) per configurar la base de dades per usar amb OTPs!</string>
   <string name="otp_discarded_because_no_db">Seleccioneu primer de base de dades. OTP es descarta per motius de seguretat.</string>

--- a/src/keepass2android/Resources/values-cs/strings.xml
+++ b/src/keepass2android/Resources/values-cs/strings.xml
@@ -459,7 +459,6 @@
   <string name="init_otp">Otevřít pomocný soubor OTP&#8230;</string>
   <string name="otp_explanation">Zadejte další jednorázová hesla (OTP). Přejeďte po zadní straně vašeho Yubikey NEO zařízení pro vložení pomocí NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Nelze najít aplikaci, která dokáže zpracovat tuto výzvu. Prosím, nainstalujte Yubichallenge z Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Nelze načíst pomocný soubor OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Použijte OtpKeyProv plugin v KeePass 2.x (PC) pro konfiguraci databáze pro použití s OTP!</string>
   <string name="otp_discarded_because_no_db">Prosím nejprve vyberte databázi. OTP je z bezpečnostních důvodů vyřazen.</string>

--- a/src/keepass2android/Resources/values-de/strings.xml
+++ b/src/keepass2android/Resources/values-de/strings.xml
@@ -463,7 +463,6 @@ Mit dieser Option wird das Masterpasswort verschlüsselt im Android-Keystore auf
   <string name="init_otp">OTP-Hilfsdatei laden&#8230;</string>
   <string name="otp_explanation">Nächste One-Time-Passwörter (OTPs) eingeben. Halten deinen YubiKey NEO hinten an dein Gerät um über NFC einzugeben.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Es wurde keine App gefunden, die die Challenge behandeln kann. Bitte installiere Yubichallenge von Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Konnte OTP-Hilfsdatei nicht laden!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Bitte nutze das OtpKeyProv-Plugin in Keepass 2.x a PC um deine Datenbank zur Verwendung von One-Time-Passwords einzureichten!</string>
   <string name="otp_discarded_because_no_db">Bitte erst Datenbank laden. OTP wird aus Sicherheitsgründen verworfen.</string>

--- a/src/keepass2android/Resources/values-el/strings.xml
+++ b/src/keepass2android/Resources/values-el/strings.xml
@@ -458,7 +458,6 @@
   <string name="init_otp">Φόρτωση βοηθητικού αρχείου OTP&#8230;</string>
   <string name="otp_explanation">Εισάγετε τα επόμενα συνθηματικά μοναδικής χρήσης (OTP). Σαρώστε το ΝΕΟ Yubikey στο πίσω μέρος της συσκευής σας να εισέλθετε μέσω NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Δεν βρέθηκε εφαρμογή που μπορεί να χειριστεί την πρόκληση. Εγκαταστήσετε το Yubichallenge από το Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Δεν ήταν δυνατή η φόρτωση του βοηθητικού αρχείου OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Χρησιμοποιήστε το πρόσθετο OtpKeyProv σε KeePass 2.x (PC) για να ρυθμίσετε τη βάση δεδομένων για χρήση με OTP!</string>
   <string name="otp_discarded_because_no_db">Επιλέξτε πρώτα την βάση δεδομένων. Το OTP απορρίπτεται για λόγους ασφαλείας.</string>

--- a/src/keepass2android/Resources/values-es/strings.xml
+++ b/src/keepass2android/Resources/values-es/strings.xml
@@ -461,7 +461,6 @@ mediante la autenticación de huellas dactilares. Esto permite desbloquear la ba
   <string name="init_otp">Cargar archivo auxiliar de OTP&#8230;</string>
   <string name="otp_explanation">Introduzca la siguiente contraseña de único uso (OTPs). Pase su Yubikey NEO en la parte trasera de su dispositivo para introducirse a través de NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">No se pudo encontrar una aplicación que puede manejar el desafío. Por favor, instale el Yubichallenge de Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">No se pudo cargar el archivo auxiliar de OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Por favor utilice el plugin OtpKeyProv en KeePass 2.x (PC) para configurar la base de datos para su uso con OTPs!</string>
   <string name="otp_discarded_because_no_db">Primero seleccione base de datos. OTP es descartada por razones de seguridad.</string>

--- a/src/keepass2android/Resources/values-fi/strings.xml
+++ b/src/keepass2android/Resources/values-fi/strings.xml
@@ -462,7 +462,6 @@ osoitteesta https://icons8.com/icon/5570/Picture.</string>
   <string name="init_otp">Lataa OTP-aputiedosto&#8230;</string>
   <string name="otp_explanation">Syötä seuraava kertakäyttösalasana (OTP). Pyyhkäise Yubikey NEO:asi laitteesi selkämystä vasten syöttääksesi salasanasi NFC:n kautta.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Sopivaa sovellusta ei löytynyt. Asenna Yubichallenge Google Playsta.</string>
   <string name="CouldntLoadOtpAuxFile">OTP-aputiedostoa ei voitu ladata!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Käytä OtpKeyProv-laajennusta KeePass 2.x:n PC-versiossa, ja määritä tietokanta käyttämään OTP-kertakäyttösalasanoja!</string>
   <string name="otp_discarded_because_no_db">Valitse ensin tietokanta. OTP hylätään turvallisuussyistä.</string>

--- a/src/keepass2android/Resources/values-fr/strings.xml
+++ b/src/keepass2android/Resources/values-fr/strings.xml
@@ -456,7 +456,6 @@ Cela va stocker votre mot de passe maître sur cet appareil, chiffré avec Andro
   <string name="init_otp">Charger le fichier OTP auxiliaire...</string>
   <string name="otp_explanation">Entrez le prochain One-time-passwords (OTP). Glissez votre NEO Yubikey au dos de votre appareil pour y accéder via NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Impossible de trouver une application qui peut convenir. Installer Yubichallenge de Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Impossible de charger le fichier auxiliaire OTP !</string>
   <string name="CouldntLoadOtpAuxFile_Hint">S\'il vous plaît utilisez le plugin OtpKeyProv dans KeePass 2.x (PC) pour configurer votre base de données pour une utilisation avec OTPs !</string>
   <string name="otp_discarded_because_no_db">Veuillez d\'abord sélectionner la base de données. OTP est écarté pour des raisons de sécurité.</string>

--- a/src/keepass2android/Resources/values-gl-rES/strings.xml
+++ b/src/keepass2android/Resources/values-gl-rES/strings.xml
@@ -449,7 +449,6 @@
   <string name="init_otp">Cargar arquivo auxiliar OTP&#8230;</string>
   <string name="otp_explanation">Intrduza os seguintes contrasinais de un uso (OTPs). Faga pasar o seu Yubikey NEO pola parte traseira do seu dispositivo para entrar por NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Non se puido atopar unha app que poida xestionar o reto. Instale Yubichallenge desde Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Non se puido cargar o arquivo auxiliar OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Utilice o plugin OtpKeyProv en KeePass 2.x (PC) para configurar a súa base de datos para o uso con OTPs!</string>
   <string name="otp_discarded_because_no_db">Seleccione primeiro a base de datos. A OTP é descartada por razóns de seguridade.</string>

--- a/src/keepass2android/Resources/values-hu/strings.xml
+++ b/src/keepass2android/Resources/values-hu/strings.xml
@@ -462,7 +462,6 @@ Az adatbázist módosíthatja, a szinkronizálásra később is lesz lehetőség
   <string name="init_otp">OTP kiegészítő fájl betöltése&#8230;</string>
   <string name="otp_explanation">Adja meg a következő egyszer használatos jelszót/jelszavakat (OTP).  Húzza el a Yubikey NEO eszközt a telefon hátlapja fölött a jelszó/jelszavak NFC-n keresztüli beviteléhez.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">A szükséges alkalmazás detektálása sikertelen!  Telepítse a Yubichallenge alkalmazást Google Play áruházból!</string>
   <string name="CouldntLoadOtpAuxFile">OTP kiegészítő fájl betöltése nem sikerült!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Kérjük, konfigurálja az adatbázist OTP használthoz a KeePass 2.x (PC-s verzió) OtpKeyProv beépülő modulja segítségével.</string>
   <string name="otp_discarded_because_no_db">Kérjük, először az adatbázist válassza ki.  Az OTP biztonsági okokból figyelmen kívül hagyva.</string>

--- a/src/keepass2android/Resources/values-in/strings.xml
+++ b/src/keepass2android/Resources/values-in/strings.xml
@@ -454,7 +454,6 @@ Hati-hati terhadap pengintip kata sandi!</string>
   <string name="init_otp">Memuat berkas bantu OTP&#8230;</string>
   <string name="otp_explanation">Masukkan kata sandi One-time-password berikutnya (OTPs). Gesek NEO Yubikey Anda di bagian belakang perangkat Anda untuk masuk melalui NFC.</string>
   <string name="otp_hint">OTP%1$d</string>
-  <string name="YubiChallengeNotInstalled">Tidak dapat menemukan aplikasi yang dapat menangani tantangan tersebut. Harap instal Yubichallenge dari Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Tidak bisa memuat file OTP tambahan!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Silakan gunakan plugin OtpKeyProv di KeePass 2.x (PC) untuk mengkonfigurasi database Anda untuk digunakan dengan OTPs!</string>
   <string name="otp_discarded_because_no_db">Silahkan pilih database dulu. OTP dibuang karena alasan keamanan.</string>

--- a/src/keepass2android/Resources/values-it/strings.xml
+++ b/src/keepass2android/Resources/values-it/strings.xml
@@ -456,7 +456,6 @@ Questo memorizzerà la password principale su questo dispositivo, cifrata con il
   <string name="init_otp">Carico il file OTP ausiliario&#8230;</string>
   <string name="otp_explanation">Inserisci i successivi One-time-password (OTP). Scorri il tuo Yubikey NEO sul retro del tuo dispositivo per inserirli via NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Impossibile trovare un\'app che può gestire il challenge. Installa Yubichallenge da Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Impossibile caricare il file OTP ausiliario!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Devi utilizzare il plugin OtpKeyProv per KeePass 2.x (PC) per poter configurare il database per l\'utilizzo con OTP!</string>
   <string name="otp_discarded_because_no_db">Prima seleziona un database. L\'OTP viene scartata per motivi di sicurezza.</string>

--- a/src/keepass2android/Resources/values-ja/strings.xml
+++ b/src/keepass2android/Resources/values-ja/strings.xml
@@ -461,7 +461,6 @@
   <string name="init_otp">OTP 補助ファイルの読み込み&#8230;</string>
   <string name="otp_explanation">次のワンタイム パスワード (OTP) を入力してください。NFC 経由で入力するには、お使いのデバイスの背面にある Yubikey NEO をスワイプします。</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">チャレンジを処理できるアプリケーションが見つかりませんでした。Google Play から Yubichallenge をインストールしてください。</string>
   <string name="CouldntLoadOtpAuxFile">補助 OTP ファイルを読み込みできませんでした!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">KeePass 2.x (PC) の OtpKeyProv プラグインを使用して、OTP を使うようにデータベースを構成してください!</string>
   <string name="otp_discarded_because_no_db">最初のデータベースを選択してください。OTP は、セキュリティ上の理由から破棄されます。</string>

--- a/src/keepass2android/Resources/values-nb/strings.xml
+++ b/src/keepass2android/Resources/values-nb/strings.xml
@@ -402,7 +402,6 @@
   <string name="use_key_file">Bruk nøkkelfil</string>
   <string name="error_adding_keyfile">Feil ved opprettelse av nøkkelfil.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Fant ingen app som kan håndtere utfordringen. Installer YubiChallenge fra Play Butikk og prøv igjen.</string>
   <string name="TrayTotp_prefs">TrayTotp</string>
   <string name="loading">Laster inn&#8230;</string>
   <string name="plugins">Programtillegg</string>

--- a/src/keepass2android/Resources/values-nl/strings.xml
+++ b/src/keepass2android/Resources/values-nl/strings.xml
@@ -461,7 +461,6 @@ Dit zal uw hoofdwachtwoord op dit apparaat opslaan. Het wordt versleuteld door d
   <string name="init_otp">Laad OTP hulpbestand&#8230;</string>
   <string name="otp_explanation">Geef de volgende eenmalige wachtwoorden (OTPs). Veeg uw Yubikey NEO langs de achterkant van uw apparaat voor NFC invoer.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Kon geen app vinden die deze Challenge-Response kan verwerken. Installeer aub Yubichallenge via Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Kan het OTP hulpbestand niet laden!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Gebruik de OtpKeyProv plugin in KeePass 2.x (PC) om uw database in te stellen voor gebruik met OTPs!</string>
   <string name="otp_discarded_because_no_db">Selecteer eerst de database. OTP is om veiligheidsredenen verwijderd.</string>

--- a/src/keepass2android/Resources/values-pl/strings.xml
+++ b/src/keepass2android/Resources/values-pl/strings.xml
@@ -458,7 +458,6 @@ To zachowa twoje hasła główne na tym urządzeniu.
   <string name="init_otp">Ładowanie pomocniczego pliku OTP&#8230;</string>
   <string name="otp_explanation">Wprowadź kolejne hasła jednorazowe (OTPs). Zbliż swój Yubikey NEO do tylnej części swojego urządzenia aby wprowadzić przez NFC.</string>
   <string name="otp_hint">Hasło jednorazowe (OTP) %1$d</string>
-  <string name="YubiChallengeNotInstalled">Nie można znaleźć aplikacji, która potrafi obsłużyć wyzwanie. Proszę zainstalować Yubichallenge z Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Nie można załadować pomocniczego pliku OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Proszę użyć wtyczki OtpKeyProv w KeePass 2.x (PC) aby skonfigurować swoją bazę danych do korzystania z haseł jednorazowych (OTP)!</string>
   <string name="otp_discarded_because_no_db">Proszę najpierw wybrać bazę danych. Hasło jednorazowe (OTP) odrzucone ze względów bezpieczeństwa.</string>

--- a/src/keepass2android/Resources/values-pt-rBR/strings.xml
+++ b/src/keepass2android/Resources/values-pt-rBR/strings.xml
@@ -458,7 +458,6 @@
   <string name="init_otp">Carregar o arquivo auxiliar OTP&#8230;</string>
   <string name="otp_explanation">Digite o seguinte One-time-passwords (OTPs). Deslize seu Yubikey NEO na parte traseira de seu dispositivo para entrar através de NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Não foi possível encontrar um app que possa lidar com o desafio. Por favor, instale o Yubichallenge no Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Não foi possível carregar arquivo OTP auxiliar!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Por favor, use o plugin OtpKeyProv no KeePass 2.x (PC) para configurar seu banco de dados para uso com as OTPs!</string>
   <string name="otp_discarded_because_no_db">Por favor, selecione o banco de dados primeiro. OTP foi descartada por motivos de segurança.</string>

--- a/src/keepass2android/Resources/values-pt-rPT/strings.xml
+++ b/src/keepass2android/Resources/values-pt-rPT/strings.xml
@@ -461,7 +461,6 @@ Muito útil se existirem muitos resultados iguais.</string>
   <string name="init_otp">Carregar o ficheiro auxiliar OTP&#8230;</string>
   <string name="otp_explanation">Introduza o One-time-passwords (OTPs) seguinte. Passe o seu Yubikey NEO na parte traseira de seu dispositivo para entrar através de NFC.</string>
   <string name="otp_hint">%1$d OTP</string>
-  <string name="YubiChallengeNotInstalled">Não foi possível encontrar uma aplicação que possa lidar com o desafio. Por favor, instale o Yubichallenge no Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Não foi possível carregar o ficheiro auxiliar OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Por favor, use a extensão OtpKeyProv no KeePass 2.x (PC) para configurar a sua base de dados para uso com as OTPs!</string>
   <string name="otp_discarded_because_no_db">Por favor, selecione a base de dados primeiro. OTP foi descartada por motivos de segurança.</string>

--- a/src/keepass2android/Resources/values-ro/strings.xml
+++ b/src/keepass2android/Resources/values-ro/strings.xml
@@ -447,7 +447,6 @@ Aceasta va stoca parola principala pe acest aparat, criptata cu Android Keystore
   <string name="init_otp">Se încarcă fișierul auxiliar OTP&#8230;</string>
   <string name="otp_explanation">Introduceți următorul One-time-passwords (OTP). Puneți Youbikey NEO-ul vostru pe spatele aparatului pentru a introduce prin NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Nu s-a găsit o aplicație care să se ocupe de această provocare. Te rog să instalezi Yubichallenge de pe Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Nu se poate încărca fișierul auxiliar OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Te rugăm să folosești plugin-ul OtpKeyProv în KeePass 2.x (PC) pentru a configura baza de date pentru OTP-uri!</string>
   <string name="otp_discarded_because_no_db">Te rugăm să selectezi baza de date întâi. OTP este ignorat pentru motive de securitate.</string>

--- a/src/keepass2android/Resources/values-ru/strings.xml
+++ b/src/keepass2android/Resources/values-ru/strings.xml
@@ -464,7 +464,6 @@
   <string name="init_otp">Загрузить вспомогательный файл одноразовых паролей&#8230;</string>
   <string name="otp_explanation">Введите следующий одноразовый пароль (OTP). Проведите ваш Yubikey NEO на задней панели устройства через датчик NFC.</string>
   <string name="otp_hint">Одноразовый пароль %1$d</string>
-  <string name="YubiChallengeNotInstalled">Не удалось найти приложение, которое может обработать вызов. Пожалуйста, установите Yubichallenge из Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Не удалось загрузить вспомогательный файл одноразовых паролей!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Пожалуйста, используйте плагин OtpKeyProv в KeePass 2.x (ПК), чтобы настроить базу данных для использования с одноразовыми паролями!</string>
   <string name="otp_discarded_because_no_db">Сначала выберите базу данных. Одноразовый пароль не принят из соображений безопасности.</string>

--- a/src/keepass2android/Resources/values-sk/strings.xml
+++ b/src/keepass2android/Resources/values-sk/strings.xml
@@ -459,7 +459,6 @@
   <string name="init_otp">Načítať doplnkový súbor pre jednorazové heslá&#8230;</string>
   <string name="otp_explanation">Zadajte ďalšie jednorazové heslá (OTP). Priložte Yubikey NEO na zadnú stranu zariadenia alebo zadajte prostredníctvom NFC.</string>
   <string name="otp_hint">Jednorazové heslo %1$d</string>
-  <string name="YubiChallengeNotInstalled">Nepodarilo sa nájsť aplikáciu pre spracovanie tejto výzvy. Prosím nainštalujte si Yubichallenge z obchodu Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Nemožno načítať doplnkový súbor pre jednorazové heslá!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Na použitie jednorazových hesiel v databáze prosím použite prídavný modul OtpKeyProv v programe keePass 2.x (PC)!</string>
   <string name="otp_discarded_because_no_db">Najskôr vyberte databázu. Jednorazové heslo bolo vymazané z bezpečnostných dôvodov.</string>

--- a/src/keepass2android/Resources/values-sl/strings.xml
+++ b/src/keepass2android/Resources/values-sl/strings.xml
@@ -450,7 +450,6 @@
   <string name="init_otp">Naloži pomožno datoteko OTP &#8230;</string>
   <string name="otp_explanation">Vnesite naslednja gesla za enkratno uporabo (OTP-je). Potegnite svoj ključ Yubikey NEO na zadnji strani svoje naprave, da vnesete preko NFC-ja.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Programa, ki lahko opravi preizkus, ni bilo mogoče najti. Namestite Yubichallenge iz trgovine Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Pomožne datoteke OTP ni mogoče naložiti!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Uporabite vtičnik OtpKeyProv v KeePassu 2.x (PC), da nastavite svojo podatkovno zbirko za uporabo z OTP-ji!</string>
   <string name="otp_discarded_because_no_db">Najprej izberite podatkovno zbirko. OTP je zavržen zaradi varnostnih razlogov.</string>

--- a/src/keepass2android/Resources/values-sv/strings.xml
+++ b/src/keepass2android/Resources/values-sv/strings.xml
@@ -461,7 +461,6 @@ Detta kommer att spara ditt huvudlösenord på denna enhet, krypterat med Androi
   <string name="init_otp">Ladda engångslösenordsfil&#8230;</string>
   <string name="otp_explanation">Ange nästa engångslösenord. Svep din Yubikey NEO på baksidan av enheten att gå in via NFC.</string>
   <string name="otp_hint">Engångslåsenord %1$d</string>
-  <string name="YubiChallengeNotInstalled">Kunde inte hitta en app som klarar utmaningen. Installera Yubichallenge från Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Kunde inte ladda engångslösenordsfil!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Vänligen använd OtpKeyProv plugin i KeePass 2.x (PC) för att konfigurera din databas för användning med engångslåsenord!</string>
   <string name="otp_discarded_because_no_db">Välj databas först. OTP ignorerades av säkerhetsskäl.</string>

--- a/src/keepass2android/Resources/values-tr/strings.xml
+++ b/src/keepass2android/Resources/values-tr/strings.xml
@@ -461,7 +461,6 @@ Bu seçenek, ana parolanızı Android Keystore ile  şifreler ve parmak iziyle k
   <string name="init_otp">tek kullanımlık şifre yedek dosyasını yükle&#8230;</string>
   <string name="otp_explanation">Bir sonraki tek kullanımlık şifreyi (OTPs) girin. NFC ile girmek için Yubikey NEO aygıtınızın arkasına dokunun.</string>
   <string name="otp_hint">tek kullanımlık şifre %1$d</string>
-  <string name="YubiChallengeNotInstalled">Parola işleyici bir uygulama bulunamadı. Lütfen Google Play üzerinden YubiChallenge uygulamasını yükleyin.</string>
   <string name="CouldntLoadOtpAuxFile">Yedek tek kullanımlık şifre dosya yüklenemedi!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Veri tabanını tek kullanımlık şifre ile kullanıma ayarlamak için lütfen KeePass 2.x (PC) üzerinde OtpKeyProv eklentisini kullanın!</string>
   <string name="otp_discarded_because_no_db">Lütfen önce veritabanı seçin. tek kullanımlık şifre, güvenlik nedenleriyle atılır.</string>

--- a/src/keepass2android/Resources/values-uk/strings.xml
+++ b/src/keepass2android/Resources/values-uk/strings.xml
@@ -459,7 +459,6 @@
   <string name="init_otp">Завантажити допоміжний файл одноразових паролів&#8230;</string>
   <string name="otp_explanation">Введіть наступний одноразовий пароль (OTP). Проведіть ваш Yubikey NEO по задній панелі пристрою для введення за допомогою NFC.</string>
   <string name="otp_hint">Одноразовий пароль %1$d</string>
-  <string name="YubiChallengeNotInstalled">Не вдалося знайти програму, що може впоратися із завданням. Встановіть Yubichallenge із Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Не вдалося завантажити допоміжний файл одноразових паролів!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Використайте плагін OtpKeyProv в KeePass 2.x (ПК), щоб налаштувати базу даних для використання з одноразовими паролями!</string>
   <string name="otp_discarded_because_no_db">Спочатку виберіть базу даних. Одноразовий пароль відхилено з міркувань безпеки.</string>

--- a/src/keepass2android/Resources/values-vi/strings.xml
+++ b/src/keepass2android/Resources/values-vi/strings.xml
@@ -458,7 +458,6 @@
   <string name="init_otp">Tải tập tin phụ trợ OTP&#8230;</string>
   <string name="otp_explanation">Nhập mật-mã-một-lần tiếp theo (OTPs). Trượt NEO Yubikey của bạn ở mặt sau của điện thoại để nhập qua NFC.</string>
   <string name="otp_hint">OTP %1$d</string>
-  <string name="YubiChallengeNotInstalled">Không thể tìm thấy ứng dụng có thể xử lý những thách thức. Xin vui lòng cài đặt Yubichallenge từ Google Play.</string>
   <string name="CouldntLoadOtpAuxFile">Không thể tải tập tin phụ trợ OTP!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">Xin vui lòng sử dụng công cụ OtpKeyProv trong KeePass 2.x (PC) để cài đặt cấu hình cơ sở dữ liệu của bạn để sử dụng với OTPs!</string>
   <string name="otp_discarded_because_no_db">Xin vui lòng chọn cơ sở dữ liệu trước. OTP bị loại bỏ vì lý do an ninh.</string>

--- a/src/keepass2android/Resources/values-zh-rCN/strings.xml
+++ b/src/keepass2android/Resources/values-zh-rCN/strings.xml
@@ -452,7 +452,6 @@
   <string name="init_otp">加载一次性密码辅助文件......</string>
   <string name="otp_explanation">通过 NFC 刷您的 Yubikey NEO 设备来输入下一个一次性密码。</string>
   <string name="otp_hint">一次性密码 %1$d</string>
-  <string name="YubiChallengeNotInstalled">无应用程序可以处理该操作。请从 Play 商店中安装 Yubichallenge</string>
   <string name="CouldntLoadOtpAuxFile">不能加载一次性密码文件 ！</string>
   <string name="CouldntLoadOtpAuxFile_Hint">请使用 KeePass 2.x（电脑端）的 OtpKeyProv 插件来配置您的数据库使用 OTPs ！</string>
   <string name="otp_discarded_because_no_db">请先选择数据库。出于安全原因，一次性密码将被丢弃。</string>

--- a/src/keepass2android/Resources/values-zh-rTW/strings.xml
+++ b/src/keepass2android/Resources/values-zh-rTW/strings.xml
@@ -450,7 +450,6 @@
   <string name="init_otp">載入一次性密碼輔助檔...</string>
   <string name="otp_explanation">由 NFC 刷入您的 Yubikey NEO 裝置來輸入下一個一次性密碼 (OTPs)。</string>
   <string name="otp_hint">一次性密碼 %1$d</string>
-  <string name="YubiChallengeNotInstalled">無應用程式可以處理。請從 Google Play 安裝 Yubichallenge。</string>
   <string name="CouldntLoadOtpAuxFile">無法載入輔助一次性密碼檔!</string>
   <string name="CouldntLoadOtpAuxFile_Hint">欲使用一次性密碼請使用 KeePass 2.x (電腦版) 的 OtpKeyProv 外掛程式來配置資料庫!</string>
   <string name="otp_discarded_because_no_db">請先選擇資料庫。出於安全原因，一次性密碼將被丟棄。</string>

--- a/src/keepass2android/Resources/values/strings.xml
+++ b/src/keepass2android/Resources/values/strings.xml
@@ -554,7 +554,7 @@
 	<string name="init_otp">Load OTP auxiliary file…</string>
 	<string name="otp_explanation">Enter the next One-time-passwords (OTPs). Swipe your Yubikey NEO at the back of your device to enter via NFC.</string>
 	<string name="otp_hint">OTP %1$d</string>
-	<string name="YubiChallengeNotInstalled">Could not find an app that can handle the challenge. Please install Yubichallenge from Google Play.</string>
+	<string name="ykDroidNotInstalled">ykDroid app is required to use YubiKey challenge-response. Please install ykDroid from Google Play.</string>
 	<string name="CouldntLoadOtpAuxFile">Could not load auxiliary OTP file!</string>
 	<string name="CouldntLoadOtpAuxFile_Hint">Please use the OtpKeyProv plugin in KeePass 2.x (PC) to configure your database for use with OTPs!</string>
 	<string name="otp_discarded_because_no_db">Please select database first. OTP is discarded for security reasons.</string>


### PR DESCRIPTION
This PR adds support for the ykDroid challenge-response driver. YubiChallenge is retained as a fallback if ykDroid is not installed on the device.

The main benefits of ykDroid over YubiChallenge are:
- USB is supported in addition to NFC (useful for tablets without NFC and allows to use any YubiKey with Android, even if it's not a NEO)
- Clean and Material Design-compliant UI with a non-interruptive overlay instead of a fullscreen activity

ykDroid is available on Google Play (also has screenshots of Keepass2Android with ykDroid): https://play.google.com/store/apps/details?id=net.pp3345.ykdroid
Source code of ykDroid is available on GitHub: https://github.com/pp3345/ykDroid