### PR TITLE
Mark keyboard configuration changes as handled in PasswordActivity

### DIFF
--- a/src/keepass2android/Properties/AndroidManifest_debug.xml
+++ b/src/keepass2android/Properties/AndroidManifest_debug.xml
@@ -58,7 +58,7 @@
             </intent-filter>
         </activity>
 		
-		<activity android:configChanges="orientation" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
 			<intent-filter android:label="@string/app_name">
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Properties/AndroidManifest_light.xml
+++ b/src/keepass2android/Properties/AndroidManifest_light.xml
@@ -11,7 +11,7 @@
 				<category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 		</activity>
-		<activity android:configChanges="keyboardHidden|orientation" android:label="@string/app_name" android:theme="@style/MyTheme" android:name="keepass2android.PasswordActivity">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme" android:name="keepass2android.PasswordActivity">
 			<intent-filter android:label="@string/app_name">
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Properties/AndroidManifest_net.xml
+++ b/src/keepass2android/Properties/AndroidManifest_net.xml
@@ -59,7 +59,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-		<activity android:configChanges="orientation" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity"  android:windowSoftInputMode="adjustResize">
       <intent-filter android:label="@string/app_name">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/src/keepass2android/Properties/AndroidManifest_nonet.xml
+++ b/src/keepass2android/Properties/AndroidManifest_nonet.xml
@@ -43,7 +43,7 @@
             </intent-filter>
         </activity>
  
-		<activity android:configChanges="orientation" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity" android:windowSoftInputMode="adjustResize">
+		<activity android:configChanges="orientation|keyboard|keyboardHidden" android:label="@string/app_name" android:theme="@style/MyTheme_Blue" android:name="keepass2android.PasswordActivity" android:windowSoftInputMode="adjustResize">
       <intent-filter android:label="@string/app_name">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
This is a cherry-pick of a commit included in #425. It's still required for ykDroid to work correctly after 6e96021047fc5ff5fd881869bce65f9f64b9b2e1 as Android will recreate the PasswordActivity as soon as a YubiKey is plugged in via USB (the YubiKey is first detected as a hardware keyboard). This not only leads to ugly screen flickering but the activity also won't be able to correctly retrieve the result from ykDroid.