### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/src/JavaFileStorageBindings/Jars/adal-1.1.19/res/layout/http_auth_dialog.xml
+++ b/src/JavaFileStorageBindings/Jars/adal-1.1.19/res/layout/http_auth_dialog.xml
@@ -26,6 +26,7 @@
         android:hint="@string/http_auth_dialog_password"
         android:inputType="textPassword"
         android:paddingTop="10dp"
-        android:paddingBottom="20dp" />
+        android:paddingBottom="20dp"
+        android:importantForAccessibility="no" />
 
 </LinearLayout>

--- a/src/java/JavaFileStorageTest-AS/app/src/main/res/layout/sftp_credentials.xml
+++ b/src/java/JavaFileStorageTest-AS/app/src/main/res/layout/sftp_credentials.xml
@@ -46,7 +46,8 @@
             android:inputType="textPassword"
             android:singleLine="true"
             android:text=""
-			android:hint="@string/hint_pass" />
+			android:hint="@string/hint_pass"
+			android:importantForAccessibility="no" />
 		
 		<TextView android:id="@+id/initial_dir"
             android:layout_width="wrap_content"

--- a/src/java/JavaFileStorageTest-AS/app/src/main/res/layout/webdav_credentials.xml
+++ b/src/java/JavaFileStorageTest-AS/app/src/main/res/layout/webdav_credentials.xml
@@ -33,6 +33,7 @@
         android:inputType="textPassword"
         android:singleLine="true"
         android:text="$T3st17$"
-        android:hint="@string/hint_pass" />
+        android:hint="@string/hint_pass"
+        android:importantForAccessibility="no" />
 
 </LinearLayout>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.