### PR TITLE
Implement requiresSetup for PCloud.

### DIFF
--- a/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/PCloudFileStorage.java
+++ b/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/PCloudFileStorage.java
@@ -52,7 +52,7 @@ public class PCloudFileStorage extends JavaFileStorageBase
 
     @Override
     public boolean requiresSetup(String path) {
-        return true;
+        return !this.isConnected();
     }
 
     @Override
@@ -372,7 +372,7 @@ public class PCloudFileStorage extends JavaFileStorageBase
 
     private Exception convertApiError(ApiError e) {
         String strErrorCode = String.valueOf(e.errorCode());
-        if (strErrorCode.startsWith("1") || "2000".equals(strErrorCode)) {
+        if (strErrorCode.startsWith("1") || "2000".equals(strErrorCode) || "2095".equals(strErrorCode)) {
             this.clearAuthToken();
             return new UserInteractionRequiredException("Unlinked from PCloud! User must re-link.", e);
         } else if (strErrorCode.startsWith("2")) {


### PR DESCRIPTION
As advised in https://github.com/PhilippC/keepass2android/pull/523#issuecomment-416719538

Also consider error 2095 as a logout, so that the user can re-login.