### PR TITLE
Update crowdin.yml for better Chinese localiztion

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,3 +4,7 @@ files:
       /src/keepass2android/Resources/values-%two_letters_code%/%original_file_name%
     translate_attributes: '0'
     content_segmentation: '0'
+    languages_mapping:
+      two_letters_code:
+        zh-CN: zh
+        zh-TW: zh-rTW


### PR DESCRIPTION
The crowdin automation now is not friendly for Chinese. I found that zh-CN and zh-TW wrote into same zh file.
For better Chinese translation, zh-CN is used for whole zh because Simplified Chinese is the most used.
And zh-TW should be zh-rTW and zh-rHK for most Traditional Chinese users.
Details can be found here: https://medium.com/fabiohub/chinese-locale-in-android-part-2-d1cfe87b3fb2
The summary of the article is below.

> In order to support Chinese for both before & after Android 7.0 devices, the minimum resources needed to maintain will be:
> 
>     en (English)
>     zh-rHK (Traditional Chinese)
>     zh-rTW (Traditional Chinese)
>     zh (Simplified Chinese)

About cloning the zh-TW to zh-rTW and zh-rHK, I emailed Crowdin Support Team for a answer after I didn't find any methods for it using the config.
The content of email is below:

> The only workaround here I can suggest is adding another Chinese language (Chinese Traditional, Hong Kong) as we can't export one language into two separate without changing common behavior for all users.
> 
> Here is the full list of supported languages by the way, so zh-TW and zh-HK (zh-rTW and zh-rHK as per android code) are among them:
> https://support.crowdin.com/api/language-codes
> 
> You can use the same translations from Chinese Traditional and upload them for Hong Kong dialect as well. I can help you with that if you wish. Just share the project name or URL, so I can recheck it and make sure I'm on the same page.
> 
> Also, there will be no need to use mapping with %android_code% placeholder.

BTW, it is not necessary to clone zh-TW to zh-HK, but it would be much more better for Chinese localization.