### PR TITLE
Fix invalid namespace in manifests causing build failure on Linux.

### DIFF
--- a/src/keepass2android/Properties/AndroidManifest_debug.xml
+++ b/src/keepass2android/Properties/AndroidManifest_debug.xml
@@ -108,7 +108,7 @@
 				<category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 		</activity>
-		<uses-library required="false" name="com.sec.android.app.multiwindow" />
+		<uses-library android:required="false" android:name="com.sec.android.app.multiwindow" />
 		<meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
 		<meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_W" android:value="632.0dip" />
 		<meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_H" android:value="598.0dip" />

--- a/src/keepass2android/Properties/AndroidManifest_net.xml
+++ b/src/keepass2android/Properties/AndroidManifest_net.xml
@@ -132,7 +132,7 @@
 				<category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 		</activity>
-			<uses-library required="false" name="com.sec.android.app.multiwindow" />
+			<uses-library android:required="false" android:name="com.sec.android.app.multiwindow" />
 		<meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
 		<meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_W" android:value="632.0dip" />
 		<meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_H" android:value="598.0dip" />

--- a/src/keepass2android/Properties/AndroidManifest_nonet.xml
+++ b/src/keepass2android/Properties/AndroidManifest_nonet.xml
@@ -123,7 +123,7 @@
 				<category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 		</activity>
-		<uses-library required="false" name="com.sec.android.app.multiwindow" />
+		<uses-library android:required="false" android:name="com.sec.android.app.multiwindow" />
 		<meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
 		<meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_W" android:value="632.0dip" />
 		<meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_H" android:value="598.0dip" />


### PR DESCRIPTION
For your information, there are other issues that prevent the build from working out of the box on Linux:

- Legacy path to Xamarin in SamsungPass project solution (fixed in this stalled PR: https://github.com/PhilippC/Xamarin-Samsung-Pass/pull/1)
- ARME ABI support was dropped in recent NDK versions and I didn't want to downgrade. See [this patch](https://gist.github.com/gilbsgilbs/4fc996d4c454ca19ec6a6c34610531c5) that drops support in KP2A. You may want to apply it at some point.

Otherwise, building under Linux remains possible, but working on Xamarin projects without VS is still very impractical unfortunately. That's what is really preventing me from contributing more actually :disappointed: . I'm done editing huge XML files by hand :smile: .