### PR TITLE
Improved Android SDK detection in Linux build scripts

### DIFF
--- a/src/build-scripts/build-apk.sh
+++ b/src/build-scripts/build-apk.sh
@@ -3,6 +3,12 @@ set -e
 
 pushd ../keepass2android
 
-xabuild keepass2android.csproj /t:SignAndroidPackage "$@"
+# check if ANDROID_HOME is defined
+if [ -z ${ANDROID_HOME+x} ];
+then
+	xabuild keepass2android.csproj /t:SignAndroidPackage "$@"
+else
+	xabuild keepass2android.csproj /p:AndroidSdkDirectory=$ANDROID_HOME /t:SignAndroidPackage "$@"
+fi
 
 popd

--- a/src/build-scripts/build-xamarin.sh
+++ b/src/build-scripts/build-xamarin.sh
@@ -20,6 +20,12 @@ popd
 
 # call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64
 
-xabuild KeePass.sln /target:keepass2android /p:BuildProjectReferences=true /p:Configuration="Debug" /p:Platform="Any CPU" "$@"
+# check if ANDROID_HOME is defined
+if [ -z ${ANDROID_HOME+x} ];
+then
+	xabuild KeePass.sln /target:keepass2android /p:BuildProjectReferences=true /p:Configuration="Debug" /p:Platform="Any CPU" "$@"
+else
+	xabuild KeePass.sln /target:keepass2android /p:AndroidSdkDirectory=$ANDROID_HOME /p:BuildProjectReferences=true /p:Configuration="Debug" /p:Platform="Any CPU" "$@"
+fi
 
 popd


### PR DESCRIPTION
If ANDROID_HOME environment variable is set, add parameter "/p:AndroidSdkDirectory=$ANDROID_HOME" to improve the Android SDK detection.

In my system I had to add this parameter to be able to build the app. The environment variable should always be set but to be sure I added a check anyway.