### PR TITLE
Russian KP2A keyboard button labels don't fit to buttons

### DIFF
--- a/src/java/KP2ASoftkeyboard_AS/app/src/main/res/values-ru/strings_kp2a.xml
+++ b/src/java/KP2ASoftkeyboard_AS/app/src/main/res/values-ru/strings_kp2a.xml
@@ -4,7 +4,7 @@
   <string name="change_entry">Выбрать другую запись</string>
   <string name="open_entry">Выбрать запись</string>
   <string name="open_entry_for_app">Поиск записи с \"%1$s\"</string>
-  <string name="kp2a_user">Пользователь</string>
+  <string name="kp2a_user">Логин</string>
   <string name="kp2a_password">Пароль</string>
   <string name="kp2a_prefs">Параметры ввода учетных данных</string>
   <string name="kp2a_auto_fill">АвтоЗаполнение включено</string>


### PR DESCRIPTION
https://github.com/PhilippC/keepass2android/issues/913

"Логин" string is shorter than "Пользователь" and should fit to the button size.