### PR TITLE
Fix “CHANGE DATABAS” button bug

### DIFF
--- a/src/keepass2android/PasswordActivity.cs
+++ b/src/keepass2android/PasswordActivity.cs
@@ -1127,7 +1127,7 @@ namespace keepass2android
 
 			var changeDbButton = FindViewById<Button>(Resource.Id.change_db);
 			string label = changeDbButton.Text;
-			if (label.EndsWith(""))
+			if (label.EndsWith("\u2026"))
 				changeDbButton.Text = label.Substring(0, label.Length - 1);
 		    changeDbButton.Click += (sender, args) => GoToFileSelectActivity();
 


### PR DESCRIPTION
This pull request fixes a bug in v1.07b where the Change Database button on the Unlock database screen is incorrectly captioned as **CHANGE DATABAS**. The cause was a line that was incorrectly stripping the last character from the string.

![image](https://user-images.githubusercontent.com/755453/64577781-0912b000-d343-11e9-8912-f646e446fc3e.png)

The string in question, named `menu_change_db`, ends with an ellipsis (`…`) in some localizations, such as the [bg-rBG](https://github.com/PhilippC/keepass2android/blob/e166e9f75487a85eb5244b67aed6f83f74e80d01/src/keepass2android/Resources/values-bg-rBG/strings.xml#L184) localization. [The line that caused this bug](https://github.com/PhilippC/keepass2android/blob/e166e9f75487a85eb5244b67aed6f83f74e80d01/src/keepass2android/PasswordActivity.cs#L1130) was supposed to test whether the string ends in an ellipsis and, if so, to strip the ellipsis from the end. However:

* In commit f11eabe, when this line was first introduced, the character being checked was _actually_ [U+0085](https://www.fileformat.info/info/unicode/char/0085/index.htm), which is not an ellipsis ([U+2026](https://www.fileformat.info/info/unicode/char/2026/index.htm)) even though it is rendered as one in some fonts. (It looks blank on GitHub, but there’s actually an invisible character between the quotation marks.) So even then that line would not have worked correctly because it was looking for the wrong character.
* In commit ef21234, the incorrect character in PasswordActivity.cs was replaced with the Unicode replacement character `�` ([U+FFFD](https://www.fileformat.info/info/unicode/char/fffd/index.htm)), apparently as the result of an encoding error.
* In commit 0970f06, the incorrect character was deleted entirely. Now it checks whether the caption string ends with the empty string, and since this will match all strings, the last character is removed from the English localized string `Change database`, which does not end in an ellipsis so the final `e` is removed instead.

The fix is to change it so that it is properly checking for the ellipsis character, using a Unicode escape sequence to avoid future encoding errors.