### PR TITLE
Allow autofill in prerelease Brave browser.

### DIFF
--- a/src/keepass2android/Resources/xml/autofillservice.xml
+++ b/src/keepass2android/Resources/xml/autofillservice.xml
@@ -63,6 +63,12 @@
     android:name="com.brave.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.brave.browser_beta"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="com.brave.browser_nightly"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.google.android.apps.chrome"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
Propose adding the Beta and Nightly versions for Brave. I assume prerelease is fair game since Chrome Canary is on there.

![Screenshot_20210914-181449_Package Manager](https://user-images.githubusercontent.com/870746/133341232-ef59da17-7f57-4006-bd27-f9782790dc6d.jpg)
