### PR TITLE
Fix homepage URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,6 @@ Beta-releases can be obtained by opting in to the [Beta testing channel](https:/
 # How do I learn more?
 Please see the [documentation](Documentation.md).
 
-The project homepage is https://philipp.crocoll.net/keepass2android/index.html
+The project homepage is https://philipp.crocoll.net/keepass2android/index.php
 
 [![Build Status](https://www.bitrise.io/app/43a23ab54dee9f7e/status.svg?token=2vryTsMQzTX3XRPikhgRwA&branch=master)](https://www.bitrise.io/app/43a23ab54dee9f7e)


### PR DESCRIPTION
The current URL displays the following page when opened:

![screenshot](https://xbb.datahoarder.dev/VUSu3/bacIcEbO98.png/raw)

This pull request fixes this issue.