### PR TITLE
Mark passwords as sensitive when copy to clipboard

### DIFF
--- a/src/keepass2android/EntryActivity.cs
+++ b/src/keepass2android/EntryActivity.cs
@@ -982,7 +982,7 @@ namespace keepass2android
 				popupKey,
 				container,
 				anchor);
-			popupItems.Add(new CopyToClipboardPopupMenuIcon(this, _stringViews[fieldKey]));
+			popupItems.Add(new CopyToClipboardPopupMenuIcon(this, _stringViews[fieldKey], isProtected));
             if (isProtected)
             {
                 var valueView = container.FindViewById<TextView>(fieldKey == PwDefs.PasswordField ? Resource.Id.entry_password : Resource.Id.entry_extra);

--- a/src/keepass2android/EntryActivityClasses/CopyToClipboardPopupMenuIcon.cs
+++ b/src/keepass2android/EntryActivityClasses/CopyToClipboardPopupMenuIcon.cs
@@ -10,12 +10,13 @@ namespace keepass2android
 	{
 		private readonly Context _context;
 		private readonly IStringView _stringView;
+		private readonly bool _isProtected;
 
-		public CopyToClipboardPopupMenuIcon(Context context, IStringView stringView)
+		public CopyToClipboardPopupMenuIcon(Context context, IStringView stringView, bool isProtected)
 		{
 			_context = context;
 			_stringView = stringView;
-			
+			_isProtected = isProtected;
 		}
 
 		public Drawable Icon 
@@ -33,7 +34,7 @@ namespace keepass2android
 		
 		public void HandleClick()
 		{
-			CopyToClipboardService.CopyValueToClipboardWithTimeout(_context, _stringView.Text);
+			CopyToClipboardService.CopyValueToClipboardWithTimeout(_context, _stringView.Text, _isProtected);
 		}
 	}
 }

--- a/src/keepass2android/Utils/Util.cs
+++ b/src/keepass2android/Utils/Util.cs
@@ -200,9 +200,15 @@ namespace keepass2android
             return "";
         }
 		
-		public static void CopyToClipboard(Context context, String text) {
+		public static void CopyToClipboard(Context context, String text, bool isProtected) {
             Android.Content.ClipboardManager clipboardManager = (ClipboardManager)context.GetSystemService(Context.ClipboardService);
             ClipData clipData = Android.Content.ClipData.NewPlainText("KP2A", text);
+			if (isProtected)
+			{
+				var extras = clipData.Description.Extras ?? new Android.OS.PersistableBundle();
+				extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
+				clipData.Description.Extras = extras;
+			}
             clipboardManager.PrimaryClip = clipData;
 		    if (text == "")
 		    {

--- a/src/keepass2android/Utils/Util.cs
+++ b/src/keepass2android/Utils/Util.cs
@@ -205,9 +205,13 @@ namespace keepass2android
             ClipData clipData = Android.Content.ClipData.NewPlainText("KP2A", text);
 			if (isProtected)
 			{
-				var extras = clipData.Description.Extras ?? new Android.OS.PersistableBundle();
-				extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
-				clipData.Description.Extras = extras;
+				//ClipDescription.Extras is only available since 24 
+				if ((int) Build.VERSION.SdkInt >= 24)
+				{
+					var extras = clipData.Description.Extras ?? new Android.OS.PersistableBundle();
+					extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
+					clipData.Description.Extras = extras;
+				}
 			}
             clipboardManager.PrimaryClip = clipData;
 		    if (text == "")


### PR DESCRIPTION
This is to fix https://github.com/PhilippC/keepass2android/issues/2058
Fix https://github.com/PhilippC/keepass2android/issues/2071
Fix https://github.com/PhilippC/keepass2android/issues/2137

~I wasn't sure if I need to wrap the call to `.Extras` in an api version check >= 24, see [here](https://learn.microsoft.com/en-us/dotnet/api/android.content.clipdescription.extras?view=xamarin-android-sdk-12#android-content-clipdescription-extras), the [copy and paste](https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#SensitiveContent) documentation didn't seem to think it was necessary?~ (Check added)
