### PR TITLE
Add function to support 'SamsungPass v1.2.6' (fixes build failure)

### DIFF
--- a/src/keepass2android/FingerprintSamsungIdentifier.cs
+++ b/src/keepass2android/FingerprintSamsungIdentifier.cs
@@ -96,6 +96,10 @@ namespace keepass2android
 			{
 				
 			}
+			public void OnCompleted()
+			{
+				// TODO
+			}
 
 			public void OnStarted ()
 			{


### PR DESCRIPTION
This permits to fix build failure when running xamarin >= 12.1 (which is the case starting from VS 2022 on windows). There is a sibling PR in samsungpass: https://github.com/PhilippC/Xamarin-Samsung-Pass/pull/3

This commit has to be merged with the commit in SamsungPass submodule that updates SamsungPass to v1.2.6.

Commit message below:

With 1.1.3 build fails as soon as we use Xamarin.Android >= 12.1 (on all platforms) [1].

Actually, this is due the version of r8.jar shipped by Xamarin which now fails. Failure is actually normal [2], as expected, while in the past it didn't fail (problem not catched in older versions).

So the bug is actually in SamsungPass.

This PR has to be taken with caution:
- it was just to check that it would build with a newer version of SamsungPass
- The new functions that are in the jar haven't been ported except those mandatory to build
- Content is unsure and part of the code is marked as TODO
- jar was taken from a location whose trustability was not checked [3]

API for 1.2.6 can be found at [4]

[1] https://github.com/xamarin/xamarin-android/issues/7607 [2] https://issuetracker.google.com/issues/192128533 [3] https://github.com/antonjlin/Shack/blob/master/app/libs/pass-v1.2.6.jar [4] https://web.archive.org/web/20181004165435/http://img-developer.samsung.com/onlinedocs/sms/pass/index.html

Error was:
```
Error in obj/Debug/lp/12/jl/__reference__pass-v1.1.3.jar:com/samsung/android/sdk/pass/SpassFingerprint.class:

java.lang.ArrayIndexOutOfBoundsException: Index 4 out of bounds for length 4

"/tmp/keepass2android/src/KeePass.sln" (keepass2android-app target) (1) ->
"/tmp/keepass2android/src/keepass2android/keepass2android-app.csproj" (default target) (2) ->
(_CompileToDalvik target) ->
  /tmp/keepass2android/l/xamarin.android-oss/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.D8.targets(79,5): error : java.lang.ArrayIndexOutOfBoundsException :  Index 4 out of bounds for length 4 [/tmp/keepass2android/src/keepass2android/keepass2android-app.csproj]
```