### PR TITLE
Fix gitignore with Resource.designer.cs/Resource.Designer.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,6 @@ Thumbs.db
 /src/java/JavaFileStorageTest/gen/group/pals/android/lib/ui/filechooser/R.java
 /src/java/JavaFileStorageTest/gen/keepass2android/javafilestorage/R.java
 
-/src/TwofishCipher/Resources/Resource.Designer.cs
 /src/BindingLibrary1
 
 /src/PluginTOTP

--- a/src/Kp2aBusinessLogic/Kp2aBusinessLogic.csproj
+++ b/src/Kp2aBusinessLogic/Kp2aBusinessLogic.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>keepass2android</RootNamespace>
     <AssemblyName>Kp2aBusinessLogic</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>

--- a/src/TwofishCipher/TwofishCipher.csproj
+++ b/src/TwofishCipher/TwofishCipher.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>TwofishCipher</RootNamespace>
     <AssemblyName>TwofishCipher</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
@@ -54,7 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Resources\Resource.Designer.cs" />
+    <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Twofish.cs" />
     <Compile Include="TwofishBase.cs" />


### PR DESCRIPTION
Default value for `<AndroidResgenFile>` is Resource.designer.cs https://learn.microsoft.com/en-us/xamarin/android/deploy-test/building-apps/build-properties#androidresgenfile

Two projects were using `<AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>` All other projects use `<AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>` Difference is one has uppercase D, the other lowercase d

.gitignore already has a rule for 'Resource.designer.cs' in it.

The two projects that were with Resource.Designer.cs needed either a specific line in gitignore or weren't actually ignored.

Selected fix here is to rename the file with a lowercase 'd' instead of uppercase. This permits to remove one line from .gitignore and keep the other file really ignored