### PR TITLE
Bugfix for #2223 - crash after import database by SFTP

### DIFF
--- a/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/SftpUserInfo.java
+++ b/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/SftpUserInfo.java
@@ -51,7 +51,12 @@ public class SftpUserInfo implements UserInfo {
 				intent.putExtra("keepass2android.sftp.prompt", text);
 				intent.setData((Uri.parse("suckit://"+SystemClock.elapsedRealtime())));
 
-				PendingIntent contentIntent = PendingIntent.getActivity(_appContext, 0, intent, 0);
+				int flags = 0;
+				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+					flags |= PendingIntent.FLAG_MUTABLE;
+				}
+				PendingIntent contentIntent = PendingIntent.getActivity(_appContext, 0, intent, flags);
+
 				builder.setContentIntent(contentIntent);
 
 				{


### PR DESCRIPTION
Add `FLAG_MUTABLE` flag to `PendingIntent` call for API >= 31 to fix an issue where trying to open an SFTP database (transition to choose a remote database file) crashes and returns to the Open/New database screen.

Fixes #2223 