### PR TITLE
Add issue templates for bug report, feature request, and question

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -30,22 +30,24 @@ body:
           1. Click the **⁝** icon in the top right corner
           2. Select **Settings**
           3. Click **About**
-          4. Find the "Version" information and provide it here
+          4. Find the "Version" information and provide it below
   - type: input
     id: version
     attributes:
       label: "What version of Keepass2Android are you using?"
     validations:
       required: true
-  - type: textarea
+  - type: markdown
+    attributes:
+      value: |
+        Please follow these steps to find your Android version:
+        1. Open your device's **Settings** app
+        2. Scroll down and select **About phone** or **About tablet**
+        3. Find the **Android version** section and provide it below
+  - type: input
     id: os
     attributes:
-      label: Which version of Android are you on?
-      placeholder: |
-        Please follow these steps to find your Android version:
-        1. Open your device's **Settings** app.
-        2. Scroll down and select **About phone** or **About tablet**.
-        3. Find the **Android version** section and provide it here.
+      label: "Which version of Android are you on?"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: Report a bug.
+title: "[BUG] "
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check out the [FAQ section](https://github.com/PhilippC/keepass2android/blob/master/docs/Documentation.md#faq) and [search for open issues](https://github.com/PhilippC/keepass2android/issues?q=is%3Aopen+is%3Aissue+label%3Abug) first.
+  - type: checkboxes
+    attributes:
+      label: Checks
+      options:
+        - label: I have read the FAQ section, searched the open issues, and still think this is a new bug.
+          required: true
+  - type: textarea
+    id: bug
+    attributes:
+      label: "Describe the bug you encountered:"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Describe what you expected to happen:"
+  - type: input
+    id: version
+    attributes:
+      label: "What version of Keepass2Android are you using?"
+      placeholder: |
+        Please follow these steps to find your app version:
+        1. Click the **⁝** icon in the top right corner
+        2. Select **Settings**
+        3. Click **About**
+        4. Find the "Version" information and provide it here
+    validations:
+      required: true
+  - type: textarea
+    id: os
+    attributes:
+      label: Which version of Android are you on?
+      placeholder: |
+        Please follow these steps to find your Android version:
+        1. Open your device's **Settings** app.
+        2. Scroll down and select **About phone** or **About tablet**.
+        3. Find the **Android version** section and provide it here.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -23,16 +23,18 @@ body:
     id: expected
     attributes:
       label: "Describe what you expected to happen:"
+  - type: markdown
+    attributes:
+      value: |
+          Please follow these steps to find your app version:
+          1. Click the **⁝** icon in the top right corner
+          2. Select **Settings**
+          3. Click **About**
+          4. Find the "Version" information and provide it here
   - type: input
     id: version
     attributes:
       label: "What version of Keepass2Android are you using?"
-      placeholder: |
-        Please follow these steps to find your app version:
-        1. Click the **⁝** icon in the top right corner
-        2. Select **Settings**
-        3. Click **About**
-        4. Find the "Version" information and provide it here
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+---
+name: Feature Request
+about: Suggest an idea for this project.
+title: ''
+labels: enhancement
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest an idea for this project.
-title: ''
+title: '[FEAT] '
 labels: enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Ask a question about 'Keepass2Android'.
-title: ''
+title: '[QUESTION] '
 labels: question
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask a question about 'Keepass2Android'.
+title: ''
+labels: question
+assignees: ''
+
+---
+
+**What version of Keepass2Android are you using?**
+Please follow these steps to find your app version:
+1. Click the **⁝** icon in the top right corner
+2. Select **Settings**
+3. Click **About**
+4. Find the "Version" information and provide it here:
+


### PR DESCRIPTION
This PR adds issue templates for bug report, feature request, and question to the .github/ISSUE_TEMPLATE directory. The project currently has over 900 open issues, and the addition of these templates will standardize the information provided in issues and make it easier for contributors to provide the necessary information.

The bug report template includes checkboxes to ensure that the FAQ has been checked and open issues have been searched before submitting a new bug report. The feature request template is a simple template for suggesting new ideas for the project. The question template asks for the version of Keepass2Android being used to help with troubleshooting.

Prefixes have been added to issue titles to improve consistency and make it easier to identify the type of issue. This could be used with the [RegEx Issue Labeler](https://github.com/marketplace/actions/regex-issue-labeler) Action to label issues automatically.

Overall, these changes should help streamline the issue creation process and ensure that all necessary information is provided upfront, making it easier for maintainers to address issues efficiently.