### PR TITLE
Bugfix for issue #2423 - FTP contents invisible

### DIFF
--- a/src/Kp2aBusinessLogic/Io/NetFtpFileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/NetFtpFileStorage.cs
@@ -288,8 +288,20 @@ namespace keepass2android.Io
 			{
                 using (var client = GetClient(ioc))
 				{
+                    /*
+					 * For some reason GetListing(path) does not always return the contents of the directory.
+					 * However, calling SetWorkingDirectory(path) followed by GetListing(null, options) to
+					 * list the contents of the working directory does consistently work.
+					 * 
+					 * Similar behavior was confirmed using ncftp client. I suspect this is a strange
+					 * bug/nuance in the server's implementation of the LIST command?
+					 *
+					 * [bug #2423]
+					 */
+                    client.SetWorkingDirectory(IocToLocalPath(ioc));
+
 					List<FileDescription> files = new List<FileDescription>();
-					foreach (FtpListItem item in client.GetListing(IocToLocalPath(ioc),
+					foreach (FtpListItem item in client.GetListing(null,
 						FtpListOption.Modify | FtpListOption.Size | FtpListOption.DerefLinks))
 					{
 


### PR DESCRIPTION
Change working directory to target path and call GetListing on current directory instead of calling GetListing on explicit path.

For some reason GetListing(path) does not always return the contents of the directory. However, calling SetWorkingDirectory(path) followed by GetListing(null, options) to list the contents of the working directory does consistently work.

Similar behavior was confirmed using ncftp client. I suspect this is a strange bug/nuance in the server's implementation of the LIST command?