### PR TITLE
CI maintenance because of deprecations on Oct 15 and Nov 30 2024

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   #   runs-on: macos-12
 
   #   steps:
-  #   - uses: actions/checkout@v3
+  #   - uses: actions/checkout@v4
 
   #   - name: Fetch submodules
   #     run: git submodule init && git submodule update
@@ -130,7 +130,7 @@ jobs:
   #       # Build Artifact of xamarin.android-oss dated 2022-02-16, master branch (= version 12.2.99)
   #       xamarin_url: https://artprodcus3.artifacts.visualstudio.com/Ad0adf05a-e7d7-4b65-96fe-3f3884d42038/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL3hhbWFyaW4vcHJvamVjdElkLzZmZDNkODg2LTU3YTUtNGUzMS04ZGI3LTUyYTFiNDdjMDdhOC9idWlsZElkLzU0OTUzL2FydGlmYWN0TmFtZS9pbnN0YWxsZXJzLXVuc2lnbmVkKy0rTGludXg1/content?format=zip
   #   steps:
-  #   - uses: actions/checkout@v3
+  #   - uses: actions/checkout@v4
 
   #   - name: Fetch submodules
   #     run: git submodule init && git submodule update
@@ -254,7 +254,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
   #       # $VM_ASSETS/select-xamarin-sdk-v2.sh --mono=6.12 --android=11.2
 
   #   - name: Switch to JDK-11
-  #     uses: actions/setup-java@v3
+  #     uses: actions/setup-java@v4
   #     with:
   #       java-version: '11'
   #       distribution: 'temurin'
@@ -181,7 +181,7 @@ jobs:
   #       echo "$HOME/xamarin.android-oss/bin/Release/bin" >> $GITHUB_PATH
 
   #   - name: Switch to JDK-11
-  #     uses: actions/setup-java@v3
+  #     uses: actions/setup-java@v4
   #     with:
   #       java-version: '11'
   #       distribution: 'temurin'
@@ -281,7 +281,7 @@ jobs:
       #uses: ilammy/msvc-dev-cmd@v1
 
     - name: Switch to JDK-11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   #     run: git submodule init && git submodule update
 
   #   - name: Setup Gradle
-  #     uses: gradle/actions/setup-gradle@v3
+  #     uses: gradle/actions/setup-gradle@v4
 
   #   - name: Cache NuGet packages
   #     uses: actions/cache@v3
@@ -136,7 +136,7 @@ jobs:
   #     run: git submodule init && git submodule update
 
   #   - name: Setup Gradle
-  #     uses: gradle/actions/setup-gradle@v3
+  #     uses: gradle/actions/setup-gradle@v4
 
   #   - name: Cache NuGet packages
   #     uses: actions/cache@v3
@@ -257,7 +257,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Cache NuGet packages
       uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
     #       D8 : OpenJDK 64-Bit Server VM warning : INFO: os::commit_memory(0x00000000ae400000, 330301440, 0) failed; error='The paging file is too small for this operation to complete' (DOS error/errno=1455) [D:\a\keepass2android\keepass2android\src\keepass2android\keepass2android-app.csproj]
     #       C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.D8.targets(81,5): error MSB6006: "java.exe" exited with code 1. [D:\a\keepass2android\keepass2android\src\keepass2android\keepass2android-app.csproj]
     - name: Configure Pagefile
-      uses: al-cheb/configure-pagefile-action@v1.3
+      uses: al-cheb/configure-pagefile-action@v1.4
       with:
         minimum-size: 8GB
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,7 +276,7 @@ jobs:
         minimum-size: 8GB
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
       # If we want to also have nmake, use this instead
       #uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   #     run: git submodule init && git submodule update
 
   #   - name: Setup Gradle
-  #     uses: gradle/gradle-build-action@v2
+  #     uses: gradle/actions/setup-gradle@v3
 
   #   - name: Cache NuGet packages
   #     uses: actions/cache@v3
@@ -136,7 +136,7 @@ jobs:
   #     run: git submodule init && git submodule update
 
   #   - name: Setup Gradle
-  #     uses: gradle/gradle-build-action@v2
+  #     uses: gradle/actions/setup-gradle@v3
 
   #   - name: Cache NuGet packages
   #     uses: actions/cache@v3
@@ -257,7 +257,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Cache NuGet packages
       uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,8 @@ jobs:
 
   #   steps:
   #   - uses: actions/checkout@v4
-
-  #   - name: Fetch submodules
-  #     run: git submodule init && git submodule update
+  #     with:
+  #       submodules: true
 
   #   - name: Setup Gradle
   #     uses: gradle/actions/setup-gradle@v4
@@ -131,9 +130,8 @@ jobs:
   #       xamarin_url: https://artprodcus3.artifacts.visualstudio.com/Ad0adf05a-e7d7-4b65-96fe-3f3884d42038/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL3hhbWFyaW4vcHJvamVjdElkLzZmZDNkODg2LTU3YTUtNGUzMS04ZGI3LTUyYTFiNDdjMDdhOC9idWlsZElkLzU0OTUzL2FydGlmYWN0TmFtZS9pbnN0YWxsZXJzLXVuc2lnbmVkKy0rTGludXg1/content?format=zip
   #   steps:
   #   - uses: actions/checkout@v4
-
-  #   - name: Fetch submodules
-  #     run: git submodule init && git submodule update
+  #     with:
+  #       submodules: true
 
   #   - name: Setup Gradle
   #     uses: gradle/actions/setup-gradle@v4
@@ -255,6 +253,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
@@ -266,9 +266,6 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/**/packages.config') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
-
-    - name: Fetch submodules
-      run: git submodule init && git submodule update
 
     # Workaround an issue when building on windows-2022. Error was
     #       D8 : OpenJDK 64-Bit Server VM warning : INFO: os::commit_memory(0x00000000ae400000, 330301440, 0) failed; error='The paging file is too small for this operation to complete' (DOS error/errno=1455) [D:\a\keepass2android\keepass2android\src\keepass2android\keepass2android-app.csproj]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
     #       D8 : OpenJDK 64-Bit Server VM warning : INFO: os::commit_memory(0x00000000ae400000, 330301440, 0) failed; error='The paging file is too small for this operation to complete' (DOS error/errno=1455) [D:\a\keepass2android\keepass2android\src\keepass2android\keepass2android-app.csproj]
     #       C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.D8.targets(81,5): error MSB6006: "java.exe" exited with code 1. [D:\a\keepass2android\keepass2android\src\keepass2android\keepass2android-app.csproj]
     - name: Configure Pagefile
-      uses: al-cheb/configure-pagefile-action@v1.4
+      uses: al-cheb/configure-pagefile-action@a3b6ebd6b634da88790d9c58d4b37a7f4a7b8708 # v1.4
       with:
         minimum-size: 8GB
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   #     uses: gradle/actions/setup-gradle@v4
 
   #   - name: Cache NuGet packages
-  #     uses: actions/cache@v3
+  #     uses: actions/cache@v4
   #     with:
   #       path: ~/.nuget/packages
   #       key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/**/packages.config') }}
@@ -139,7 +139,7 @@ jobs:
   #     uses: gradle/actions/setup-gradle@v4
 
   #   - name: Cache NuGet packages
-  #     uses: actions/cache@v3
+  #     uses: actions/cache@v4
   #     with:
   #       path: ~/.nuget/packages
   #       key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/**/packages.config') }}
@@ -148,7 +148,7 @@ jobs:
 
   #   - name: Cache Xamarin.Android packages
   #     id: xamarin_cache
-  #     uses: actions/cache@v3
+  #     uses: actions/cache@v4
   #     with:
   #       path: ~/xamarin.android-oss
   #       key: ${{ runner.os }}-xamarin.android-oss-${{ env.xamarin_url }}
@@ -260,7 +260,7 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
 
     - name: Cache NuGet packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/**/packages.config') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
   #       make apk Flavor=Net
 
   #   - name: Archive production artifacts (net)
-  #     uses: actions/upload-artifact@v3
+  #     uses: actions/upload-artifact@v4
   #     with:
   #       name: signed APK ('net' built on ${{ github.job }})
   #       path: |
@@ -99,7 +99,7 @@ jobs:
   #       make apk Flavor=NoNet
 
   #   - name: Archive production artifacts (nonet)
-  #     uses: actions/upload-artifact@v3
+  #     uses: actions/upload-artifact@v4
   #     with:
   #       name: signed APK ('nonet' built on ${{ github.job }})
   #       path: |
@@ -215,7 +215,7 @@ jobs:
   #       make apk Flavor=Net
 
   #   - name: Archive production artifacts (net)
-  #     uses: actions/upload-artifact@v3
+  #     uses: actions/upload-artifact@v4
   #     with:
   #       name: signed APK ('net' built on ${{ github.job }})
   #       path: |
@@ -233,7 +233,7 @@ jobs:
   #       make apk Flavor=NoNet
 
   #   - name: Archive production artifacts (nonet)
-  #     uses: actions/upload-artifact@v3
+  #     uses: actions/upload-artifact@v4
   #     with:
   #       name: signed APK ('nonet' built on ${{ github.job }})
   #       path: |
@@ -317,7 +317,7 @@ jobs:
         make apk Flavor=Net
 
     - name: Archive production artifacts (net)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: signed APK ('net' built on ${{ github.job }})
         path: |
@@ -338,7 +338,7 @@ jobs:
         make apk Flavor=NoNet
 
     - name: Archive production artifacts (nonet)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: signed APK ('nonet' built on ${{ github.job }})
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   #       submodules: true
 
   #   - name: Setup Gradle
-  #     uses: gradle/actions/setup-gradle@v4
+  #     uses: gradle/actions/setup-gradle@v3
 
   #   - name: Cache NuGet packages
   #     uses: actions/cache@v4
@@ -134,7 +134,7 @@ jobs:
   #       submodules: true
 
   #   - name: Setup Gradle
-  #     uses: gradle/actions/setup-gradle@v4
+  #     uses: gradle/actions/setup-gradle@v3
 
   #   - name: Cache NuGet packages
   #     uses: actions/cache@v4
@@ -257,7 +257,7 @@ jobs:
         submodules: true
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Cache NuGet packages
       uses: actions/cache@v4

--- a/src/java/JavaFileStorage/app/build.gradle
+++ b/src/java/JavaFileStorage/app/build.gradle
@@ -31,7 +31,7 @@ NOTE: If you change dependencies here, don't forget to update the jar files in J
 dependencies {
 
     implementation 'com.squareup.okhttp3:okhttp:4.10.0-RC1'
-    implementation 'com.burgstaller:okhttp-digest:2.5'
+    implementation 'io.github.rburgst:okhttp-digest:2.5'
 
     implementation 'com.google.http-client:google-http-client-gson:1.20.0'
     implementation('com.google.api-client:google-api-client-android:1.30.5') {


### PR DESCRIPTION
**What**

I made small careful commits and tried to explain each in their message. Reviewing this PR commit-by-commit might be the easiest way to understand it.

**Why**

https://github.blog/changelog/label/actions+deprecation/ is a good resource for staying up-to-date on action deprecations. There are a few that would affect this repo, so I went ahead and updated the build workflow.

1. [End of life for Actions Node16](https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/)

    > From the 15th of October, we will no longer include Node16 in the Actions runner and customers will no longer be able to use Node16 Actions or operating systems that do not support Node20.
 
2. [Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

    > Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.

***

I like this app quite a bit, hopefully this PR is helpful. Thanks for all the work so far.