### PR TITLE
Prevent duplicate CI runs in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build keepass2android app
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   # macos:


### PR DESCRIPTION
At https://github.com/PhilippC/keepass2android/pull/2692/commits:
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/02ed0a3d-9a18-4bf5-a252-59f0c7e152bb" />

Happened to notice, no need to run the same workflow twice in PRs.

Happy holidays!