### PR TITLE
Remove deprecated Firefox Nightly app ID from trusted browsers

### DIFF
--- a/src/keepass2android-app/services/AutofillBase/Kp2aDigitalAssetLinksDataSource.cs
+++ b/src/keepass2android-app/services/AutofillBase/Kp2aDigitalAssetLinksDataSource.cs
@@ -71,7 +71,7 @@ namespace keepass2android.services.AutofillBase
         static readonly HashSet<string> _trustedBrowsers = new HashSet<string>
         {
             "org.mozilla.firefox","org.mozilla.firefox_beta","org.mozilla.klar","org.mozilla.focus",
-            "org.mozilla.fenix","org.mozilla.fenix.nightly","org.mozilla.reference.browser",
+            "org.mozilla.fenix","org.mozilla.reference.browser",
             "com.android.browser","com.android.chrome","com.chrome.beta","com.chrome.dev","com.chrome.canary",
             "com.google.android.apps.chrome","com.google.android.apps.chrome_dev",
             "com.opera.browser","com.opera.browser.beta","com.opera.mini.native","com.opera.mini.native.beta","com.opera.touch",


### PR DESCRIPTION
This app ID has not been used for a few years now and can be safely removed. 

See the original PR for added context: https://github.com/PhilippC/keepass2android/pull/896