### PR TITLE
upgrade to target sdk 34: mark OngoingNotificationsService as Use, register receivers as exported

### DIFF
--- a/src/keepass2android-app/EntryActivity.cs
+++ b/src/keepass2android-app/EntryActivity.cs
@@ -491,9 +491,9 @@ namespace keepass2android
 			App.Kp2a.LastOpenedEntry = new PwEntryOutput(Entry, App.Kp2a.CurrentDb);
 
 			_pluginActionReceiver = new PluginActionReceiver(this);
-			RegisterReceiver(_pluginActionReceiver, new IntentFilter(Strings.ActionAddEntryAction));
+			RegisterReceiver(_pluginActionReceiver, new IntentFilter(Strings.ActionAddEntryAction), ReceiverFlags.Exported);
 			_pluginFieldReceiver = new PluginFieldReceiver(this);
-			RegisterReceiver(_pluginFieldReceiver, new IntentFilter(Strings.ActionSetEntryField));
+			RegisterReceiver(_pluginFieldReceiver, new IntentFilter(Strings.ActionSetEntryField), ReceiverFlags.Exported);
 
             var notifyPluginsOnOpenThread = new Thread(NotifyPluginsOnOpen);
             notifyPluginsOnOpenThread.Start();

--- a/src/keepass2android-app/LockCloseActivity.cs
+++ b/src/keepass2android-app/LockCloseActivity.cs
@@ -69,7 +69,7 @@ namespace keepass2android
 			IntentFilter filter = new IntentFilter();
 			filter.AddAction(Intents.DatabaseLocked);
 			filter.AddAction(Intent.ActionScreenOff);
-			RegisterReceiver(_intentReceiver, filter);
+			RegisterReceiver(_intentReceiver, filter, ReceiverFlags.Exported);
 		}
 
 		protected override void OnDestroy()

--- a/src/keepass2android-app/LockCloseListActivity.cs
+++ b/src/keepass2android-app/LockCloseListActivity.cs
@@ -55,7 +55,7 @@ namespace keepass2android
 
 			filter.AddAction(Intents.DatabaseLocked);
 			filter.AddAction(Intent.ActionScreenOff);
-			RegisterReceiver(_intentReceiver, filter);
+			RegisterReceiver(_intentReceiver, filter, ReceiverFlags.Exported);
 
 		}
 		

--- a/src/keepass2android-app/LockingClosePreferenceActivity.cs
+++ b/src/keepass2android-app/LockingClosePreferenceActivity.cs
@@ -39,7 +39,7 @@ namespace keepass2android
 			_intentReceiver = new LockCloseActivityBroadcastReceiver(this);
 			IntentFilter filter = new IntentFilter();
 			filter.AddAction(Intents.DatabaseLocked);
-			RegisterReceiver(_intentReceiver, filter);
+			RegisterReceiver(_intentReceiver, filter, ReceiverFlags.Exported);
 		}
 
 		protected override void OnResume() {

--- a/src/keepass2android-app/Manifests/AndroidManifest_debug.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_debug.xml
@@ -43,7 +43,7 @@
   </queries>
 
 
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="34" />
   <permission android:description="@string/permission_desc2" android:icon="@drawable/ic_notify_locked" android:label="KP2A entry search" android:name="keepass2android.keepass2android_debug.permission.KP2aInternalSearch" android:protectionLevel="signature" />
   <permission android:description="@string/permission_desc3" android:icon="@drawable/ic_launcher" android:label="KP2A choose autofill dataset" android:name="keepass2android.keepass2android_debug.permission.Kp2aChooseAutofill" android:protectionLevel="signature" />
   <application
@@ -256,6 +256,7 @@ The scheme=file is still there for old OS devices. It's also queried by apps lik
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.GET_ACCOUNTS" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <uses-permission android:name="android.permission.USE_CREDENTIALS" android:maxSdkVersion="22" />
   <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" android:maxSdkVersion="22" />
   <uses-permission android:name="keepass2android.keepass2android_debug.permission.KP2aInternalFileBrowsing" />

--- a/src/keepass2android-app/Manifests/AndroidManifest_net.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_net.xml
@@ -42,7 +42,7 @@
       <action android:name="android.intent.action.VIEW" />
     </intent>
   </queries>
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="34" />
 
   <permission android:description="@string/permission_desc2" android:icon="@drawable/ic_launcher" android:label="KP2A entry search" android:name="keepass2android.keepass2android.permission.KP2aInternalSearch" android:protectionLevel="signature" />
   <permission android:description="@string/permission_desc3" android:icon="@drawable/ic_launcher" android:label="KP2A choose autofill dataset" android:name="keepass2android.keepass2android.permission.Kp2aChooseAutofill" android:protectionLevel="signature" />
@@ -270,6 +270,7 @@ The scheme=file is still there for old OS devices. It's also queried by apps lik
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.GET_ACCOUNTS" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <uses-permission android:name="android.permission.USE_CREDENTIALS" android:maxSdkVersion="22" />
   <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" android:maxSdkVersion="22" />
   <uses-permission android:name="keepass2android.keepass2android.permission.KP2aInternalFileBrowsing" />

--- a/src/keepass2android-app/Manifests/AndroidManifest_nonet.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_nonet.xml
@@ -40,7 +40,7 @@
 	  </intent>
   </queries>			
 			
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="34" />
   <permission android:description="@string/permission_desc2" android:icon="@drawable/ic_launcher_offline" android:label="KP2A entry search" android:name="keepass2android.keepass2android_nonet.permission.KP2aInternalSearch" android:protectionLevel="signature" />
   <permission android:description="@string/permission_desc3" android:icon="@drawable/ic_launcher_offline" android:label="KP2A choose autofill dataset" android:name="keepass2android.keepass2android_nonet.permission.Kp2aChooseAutofill" android:protectionLevel="signature" />
 	<application 

--- a/src/keepass2android-app/PasswordActivity.cs
+++ b/src/keepass2android-app/PasswordActivity.cs
@@ -647,7 +647,7 @@ namespace keepass2android
 		    _intentReceiver = new PasswordActivityBroadcastReceiver(this);
 			IntentFilter filter = new IntentFilter();
 			filter.AddAction(Intent.ActionScreenOff);
-			RegisterReceiver(_intentReceiver, filter);
+			RegisterReceiver(_intentReceiver, filter, ReceiverFlags.Exported);
 
 
             //use FlagSecure to make sure the last (revealed) character of the master password is not visible in recent apps

--- a/src/keepass2android-app/QuickUnlock.cs
+++ b/src/keepass2android-app/QuickUnlock.cs
@@ -153,7 +153,7 @@ namespace keepass2android
 			_intentReceiver = new QuickUnlockBroadcastReceiver(this);
 			IntentFilter filter = new IntentFilter();
 			filter.AddAction(Intents.DatabaseLocked);
-			RegisterReceiver(_intentReceiver, filter);
+			RegisterReceiver(_intentReceiver, filter, ReceiverFlags.Exported);
 
             Util.SetNoPersonalizedLearning(FindViewById<EditText>(Resource.Id.QuickUnlock_password));
 
@@ -503,8 +503,6 @@ namespace keepass2android
 				}
 			}
 		}
-
-
 	}
 }
 

--- a/src/keepass2android-app/SelectCurrentDbActivity.cs
+++ b/src/keepass2android-app/SelectCurrentDbActivity.cs
@@ -343,7 +343,7 @@ namespace keepass2android
                 IntentFilter filter = new IntentFilter();
                 filter.AddAction(Intents.DatabaseLocked);
                 filter.AddAction(Intent.ActionScreenOff);
-                RegisterReceiver(_intentReceiver, filter);
+                RegisterReceiver(_intentReceiver, filter, ReceiverFlags.Exported);
             }
         }
 

--- a/src/keepass2android-app/app/App.cs
+++ b/src/keepass2android-app/app/App.cs
@@ -1342,7 +1342,7 @@ namespace keepass2android
 		    intentFilter.AddAction(Intents.LockDatabase);
             intentFilter.AddAction(Intents.LockDatabaseByTimeout);
 			intentFilter.AddAction(Intents.CloseDatabase);
-            Context.RegisterReceiver(broadcastReceiver, intentFilter);
+            Context.RegisterReceiver(broadcastReceiver, intentFilter, ReceiverFlags.Exported);
 
             //ZXing.Net.Mobile.Forms.Android.Platform.Init();
 		}

--- a/src/keepass2android-app/services/CopyToClipboardService.cs
+++ b/src/keepass2android-app/services/CopyToClipboardService.cs
@@ -322,7 +322,7 @@ namespace keepass2android
                 _stopOnLockBroadcastReceiver = new StopOnLockBroadcastReceiver(this);
                 IntentFilter filter = new IntentFilter();
                 filter.AddAction(Intents.DatabaseLocked);
-                RegisterReceiver(_stopOnLockBroadcastReceiver, filter);
+                RegisterReceiver(_stopOnLockBroadcastReceiver, filter, ReceiverFlags.Exported);
             }
 
             if ((intent.Action == Intents.ShowNotification) || (intent.Action == Intents.UpdateKeyboard))
@@ -529,7 +529,7 @@ namespace keepass2android
                 _notificationDeletedBroadcastReceiver = new NotificationDeletedBroadcastReceiver(this);
                 IntentFilter deletefilter = new IntentFilter();
                 deletefilter.AddAction(ActionNotificationCancelled);
-                RegisterReceiver(_notificationDeletedBroadcastReceiver, deletefilter);
+                RegisterReceiver(_notificationDeletedBroadcastReceiver, deletefilter, ReceiverFlags.Exported);
             }
             
         }

--- a/src/keepass2android-app/services/OngoingNotificationsService.cs
+++ b/src/keepass2android-app/services/OngoingNotificationsService.cs
@@ -18,6 +18,7 @@ This file is part of Keepass2Android, Copyright 2013 Philipp Crocoll. This file 
 using System;
 using Android.App;
 using Android.Content;
+using Android.Content.PM;
 using Android.Graphics;
 using Android.OS;
 using Android.Preferences;
@@ -37,7 +38,9 @@ namespace keepass2android
 	/// used by the user. This ensures the database is kept in memory (until Android kills it due to low memory).
 	/// It is important to also have a foreground service also for the "unlocked" state because it's really
 	/// irritating if the db is closed while switching between apps.
-	[Service]
+	[Service(ForegroundServiceType = ForegroundService.TypeSpecialUse )]
+	[MetaData("android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE", Value = " This service is running as foreground service to keep the app alive even when it's not currently used by the user. This ensures the database is kept in memory (until Android kills it due to low memory). It is important to also have a foreground service also for the \"unlocked\" state because it's really irritating if the db is closed while switching between apps.")]
+	
 	public class OngoingNotificationsService : Service
 	{
 		protected override void AttachBaseContext(Context baseContext)
@@ -57,7 +60,7 @@ namespace keepass2android
 			_screenOffReceiver = new ScreenOffReceiver();
 			IntentFilter filter = new IntentFilter();
 			filter.AddAction(Intent.ActionScreenOff);
-			RegisterReceiver(_screenOffReceiver, filter);
+			RegisterReceiver(_screenOffReceiver, filter, ReceiverFlags.Exported);
 		}
 
 


### PR DESCRIPTION
Exported receivers are required because it is allowed that plugins send intents and also intents from system notifications are not received in NonExported mode.