### PR TITLE
Bugfix: Webdav username and password could got lost during file selection

### DIFF
--- a/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/WebDavStorage.java
+++ b/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/WebDavStorage.java
@@ -304,6 +304,11 @@ public class WebDavStorage extends JavaFileStorageBase {
                         //relative path:
                         e.path = buildPathFromHref(parentPath, r.href);
                     }
+                    if ( (parentPath.indexOf("@") != -1) && (e.path.indexOf("@") == -1))
+                    {
+                        //username/password not contained in .href response. Add it back from parentPath:
+                        e.path = parentPath.substring(0, parentPath.indexOf("@")+1) + e.path.substring(e.path.indexOf("://")+3);
+                    }
 
                     if ((depth == 1) && e.isDirectory)
                     {


### PR DESCRIPTION
This issue seems to depend on server behavior in PROPFIND request. This PR fixes this for these cases.