### PR TITLE
improve help texts

### DIFF
--- a/src/keepass2android-app/EntryEditActivity.cs
+++ b/src/keepass2android-app/EntryEditActivity.cs
@@ -37,6 +37,7 @@ using System.Net;
 using System.Text;
 using Android.Content.Res;
 using Android.Database;
+using Android.Gms.Common;
 using Android.Gms.Tasks;
 using Android.Graphics;
 using Android.Graphics.Drawables;
@@ -1155,6 +1156,12 @@ namespace keepass2android
 
             dlgView.FindViewById<Button>(Resource.Id.totp_scan).Click += async (object o, EventArgs args) =>
             {
+                if (GoogleApiAvailability.Instance.IsGooglePlayServicesAvailable(this) != ConnectionResult.Success)
+                {
+                    Toast.MakeText(this, Resource.String.qr_scanning_error_no_google_play_services, ToastLength.Long);
+                    return;
+                }
+
 				GmsBarcodeScannerOptions options = new GmsBarcodeScannerOptions.Builder()
                     .SetBarcodeFormats(Barcode.FormatQrCode)
                     .Build();

--- a/src/keepass2android-app/Resources/values/strings.xml
+++ b/src/keepass2android-app/Resources/values/strings.xml
@@ -548,6 +548,7 @@
   <string name="filestoragename_dropboxKP2A">Dropbox (KP2A folder)</string>
   <string name="filestoragehelp_dropboxKP2A">If you do not want to give KP2A access to your full Dropbox, you may select this option. It will request only access to the folder Apps/Keepass2Android. This is especially suited when creating a new database. If you already have a database, select this option to create the folder, then place your file inside the folder (from your PC) and then select this option again for opening the file.</string>
   <string name="filestoragename_gdrive">Google Drive</string>
+  <string name="filestoragehelp_gdrive">Please note: Google is restricting access to Google Drive from apps for more and more users. If the built-in Google Drive implementation does not work, please use System file picker instead and select Google Drive there!</string>
   <string name="filestoragename_gdriveKP2A">Google Drive (KP2A files)</string>
   <string name="filestoragehelp_gdriveKP2A">If you do not want to give KP2A access to your full Google Drive, you may select this option. Note that you need to create a database file first, existing files are not visible to the app. Either choose this option from the Create database screen or, if you already opened a database, by exporting the database choosing this option.</string>
   <string name="filestoragename_pcloud">PCloud (KP2A folder)</string>
@@ -1245,6 +1246,7 @@
   <string name="AutofillWarning_trustAsBrowser">Accept always in "%1$s"</string>
   <string name="kp2a_switch_on_sendgodone">Switch back when done</string>
   <string name="kp2a_switch_on_sendgodone_summary">Switch back when pressing send/go/done</string>
+  <string name="qr_scanning_error_no_google_play_services">QR code scanning requires Google Play Services. Please install or update Google Play Services on your device.</string>
 <string name="english_ime_settings">Android keyboard settings</string>
     
     </resources>


### PR DESCRIPTION
* show a toast when users without Play services are trying to scan a QR code (#2791)
* show a message informing that built-in Google Drive support is more and more restricted by Google (#2788)