### PR TITLE
use snackbars instead of toasts

### DIFF
--- a/src/Kp2aBusinessLogic/IKp2aApp.cs
+++ b/src/Kp2aBusinessLogic/IKp2aApp.cs
@@ -29,6 +29,14 @@ namespace keepass2android
 
 	}
 
+
+    public enum MessageSeverity
+    {
+        Info,
+        Warning,
+        Error
+    }
+
     /// <summary>
 	/// Interface through which Activities and the logic layer can access some app specific functionalities and Application static data
 	/// </summary>
@@ -102,10 +110,13 @@ namespace keepass2android
 		                    Context ctx,
 		                    string messageSuffix = "");
 
-		/// <summary>
-		/// Returns a Handler object which can run tasks on the UI thread
-		/// </summary>
-		Handler UiThreadHandler { get; }
+        void ShowMessage(Context ctx, int resourceId, MessageSeverity severity);
+        void ShowMessage(Context ctx, string text, MessageSeverity severity);
+
+        /// <summary>
+        /// Returns a Handler object which can run tasks on the UI thread
+        /// </summary>
+        Handler UiThreadHandler { get; }
 
 		IProgressDialog CreateProgressDialog(Context ctx);
 

--- a/src/Kp2aBusinessLogic/SelectStorageLocationActivityBase.cs
+++ b/src/Kp2aBusinessLogic/SelectStorageLocationActivityBase.cs
@@ -94,7 +94,7 @@ namespace keepass2android
 				}
 				if ((resultCode == Result.Canceled) && (data != null) && (data.HasExtra("EXTRA_ERROR_MESSAGE")))
 				{
-					ShowToast(data.GetStringExtra("EXTRA_ERROR_MESSAGE"));
+					ShowErrorToast(data.GetStringExtra("EXTRA_ERROR_MESSAGE"));
 				}
 
 				if (resultCode == Result.Ok)
@@ -150,7 +150,7 @@ namespace keepass2android
 
 		protected abstract void StartFileChooser(string path, int requestCode, bool isForSave);
 
-		protected abstract void ShowToast(string text);
+		protected abstract void ShowErrorToast(string text);
 
 		protected abstract void ShowInvalidSchemeMessage(string dataString);
 
@@ -208,7 +208,7 @@ namespace keepass2android
 					{
 						return () =>
 							{
-								ShowToast(_app.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message);
+								ShowErrorToast(_app.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message);
 								ReturnCancel();
 							};
 					}

--- a/src/Kp2aBusinessLogic/database/edit/OnFinish.cs
+++ b/src/Kp2aBusinessLogic/database/edit/OnFinish.cs
@@ -130,24 +130,24 @@ namespace keepass2android
 			if ( !String.IsNullOrEmpty(message) ) {
 			    Kp2aLog.Log("OnFinish message: " + message);
                 if (makeDialog && ctx != null)
-			    {
-			        try
-			        {
-			            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(ctx);
-			            
-			            builder.SetMessage(message)
-			                .SetPositiveButton(Android.Resource.String.Ok, (sender, args) => ((Dialog)sender).Dismiss())
-			                .Show();
+                {
+                    try
+                    {
+                        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(ctx);
+
+                        builder.SetMessage(message)
+                            .SetPositiveButton(Android.Resource.String.Ok, (sender, args) => ((Dialog)sender).Dismiss())
+                            .Show();
 
                     }
                     catch (Exception)
-			        {
-			            Toast.MakeText(ctx, message, ToastLength.Long).Show();
-			        }
-			    }
+                    {
+                        Toast.MakeText(ctx, message, ToastLength.Long).Show();
+                    }
+                }
                 else
                     Toast.MakeText(ctx ?? Application.Context, message, ToastLength.Long).Show();
-			}
+            }
 		}
 	}
 }

--- a/src/keepass2android-app/AboutDialog.cs
+++ b/src/keepass2android-app/AboutDialog.cs
@@ -59,7 +59,7 @@ namespace keepass2android
 					}
 					catch (ActivityNotFoundException)
 					{
-						Toast.MakeText(Context, Resource.String.no_url_handler, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(Context, Resource.String.no_url_handler, MessageSeverity.Error);
 					}
 
 				};
@@ -71,7 +71,7 @@ namespace keepass2android
 				}
 				catch (ActivityNotFoundException)
 				{
-					Toast.MakeText(Context, Resource.String.no_url_handler, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(Context, Resource.String.no_url_handler,  MessageSeverity.Error);
 				}
 			};
 			FindViewById(Resource.Id.translate).Click += delegate
@@ -82,7 +82,7 @@ namespace keepass2android
 				}
 				catch (ActivityNotFoundException)
 				{
-					Toast.MakeText(Context, Resource.String.no_url_handler, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(Context, Resource.String.no_url_handler,  MessageSeverity.Error);
 				}
 			}; FindViewById(Resource.Id.donate).Click += delegate
 			{

--- a/src/keepass2android-app/CreateDatabaseActivity.cs
+++ b/src/keepass2android-app/CreateDatabaseActivity.cs
@@ -183,7 +183,7 @@ namespace keepass2android
 			// Verify that a password or keyfile is set
 			if (password.Length == 0 && !keyfileCheckbox.Checked)
 			{
-				Toast.MakeText(this, Resource.String.error_nopass, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, Resource.String.error_nopass,  MessageSeverity.Error);
 				return;
 			}
 
@@ -207,7 +207,7 @@ namespace keepass2android
 				}
 				catch (Exception)
 				{
-					Toast.MakeText(this, Resource.String.error_adding_keyfile, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(this, Resource.String.error_adding_keyfile,  MessageSeverity.Error);
 					return;
 				}
 			}
@@ -235,7 +235,7 @@ namespace keepass2android
 			if (! pass.Equals(confpass))
 			{
 				// Passwords do not match
-				Toast.MakeText(this, Resource.String.error_pass_match, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, Resource.String.error_pass_match,  MessageSeverity.Error);
 				return false;
 			}
 			return true;

--- a/src/keepass2android-app/DisableAutofillForQueryActivity.cs
+++ b/src/keepass2android-app/DisableAutofillForQueryActivity.cs
@@ -41,7 +41,7 @@ namespace keepass2android
             string requestedUrl = Intent.GetStringExtra(ChooseForAutofillActivityBase.ExtraQueryString);
             if (requestedUrl == null)
             {
-                Toast.MakeText(this, "Cannot execute query for null.", ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, "Cannot execute query for null.",  MessageSeverity.Error);
                 RestartApp();
                 return;
             }

--- a/src/keepass2android-app/EntryActivity.cs
+++ b/src/keepass2android-app/EntryActivity.cs
@@ -78,7 +78,7 @@ namespace keepass2android
             var task = new EntryActivity.WriteBinaryTask(_activity, App.Kp2a, new ActionOnFinish(_activity, (success, message, activity) =>
                 {
                     if (!success)
-                        Toast.MakeText(activity, message, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                 }
             ), ((EntryActivity)_activity).Entry.Binaries.Get(_binaryToSave), ioc);
             ProgressTask pt = new ProgressTask(App.Kp2a, _activity, task);
@@ -107,8 +107,8 @@ namespace keepass2android
 
 	    public const int requestCodeBinaryFilename = 42376;
         public const int requestCodeSelFileStorageForWriteAttachment = 42377;
-	    
 
+        protected override View? SnackbarAnchorView => FindViewById(Resource.Id.main_content);
 
         public static void Launch(Activity act, PwEntry pw, int pos, AppTask appTask, ActivityFlags? flags = null, int historyIndex=-1)
 		{
@@ -767,9 +767,9 @@ namespace keepass2android
 
 	            if (parent == null || (parent.Exists() && !parent.IsDirectory))
 	            {
-	                Toast.MakeText(this,
+	                App.Kp2a.ShowMessage(this,
 	                    Resource.String.error_invalid_path,
-	                    ToastLength.Long).Show();
+	                     MessageSeverity.Error);
 	                return null;
 	            }
 
@@ -778,9 +778,9 @@ namespace keepass2android
 	                // Create parent directory
 	                if (!parent.Mkdirs())
 	                {
-	                    Toast.MakeText(this,
+	                    App.Kp2a.ShowMessage(this,
 	                        Resource.String.error_could_not_create_parent,
-	                        ToastLength.Long).Show();
+	                         MessageSeverity.Error);
 	                    return null;
 
 	                }
@@ -794,18 +794,18 @@ namespace keepass2android
 	            }
 	            catch (Exception exWrite)
 	            {
-	                Toast.MakeText(this,
+	                App.Kp2a.ShowMessage(this,
 	                    GetString(Resource.String.SaveAttachment_Failed, new Java.Lang.Object[] {filename})
-	                    + exWrite.Message, ToastLength.Long).Show();
+	                    + exWrite.Message,  MessageSeverity.Error);
 	                return null;
 	            }
 	            finally
 	            {
 	                MemUtil.ZeroByteArray(pbData);
 	            }
-	            Toast.MakeText(this,
+	            App.Kp2a.ShowMessage(this,
 	                GetString(Resource.String.SaveAttachment_doneMessage, new Java.Lang.Object[] {filename}),
-	                ToastLength.Short).Show();
+	                 MessageSeverity.Info);
 	            return Uri.Parse("content://" + AttachmentContentProvider.Authority + "/"
 	                             + filename);
 	        }
@@ -838,7 +838,7 @@ namespace keepass2android
 				catch (ActivityNotFoundException)
 				{
 					//ignore
-					Toast.MakeText(this, "Couldn't open file", ToastLength.Short).Show();
+					App.Kp2a.ShowMessage(this, "Couldn't open file",  MessageSeverity.Error);
 				}
 			}
 
@@ -1558,7 +1558,7 @@ namespace keepass2android
 			}
 			catch (ActivityNotFoundException)
 			{
-				Toast.MakeText(this, Resource.String.no_url_handler, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, Resource.String.no_url_handler,  MessageSeverity.Error);
 			}
 			return true;
 		}

--- a/src/keepass2android-app/EntryEditActivity.cs
+++ b/src/keepass2android-app/EntryEditActivity.cs
@@ -64,10 +64,10 @@ namespace keepass2android
 {
 	[Activity(Label = "@string/app_name", ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden, Theme = "@style/Kp2aTheme_ActionBar")]			
 	public class EntryEditActivity : LockCloseActivity {
-	    
 
-	    
-		public const String KeyEntry = "entry";
+        protected override View? SnackbarAnchorView => FindViewById(Resource.Id.main_content);
+
+        public const String KeyEntry = "entry";
 		public const String KeyParent = "parent";
 		public const String KeyTemplateUuid = "KeyTemplateUuid";
 		
@@ -715,7 +715,7 @@ namespace keepass2android
 			}
 			catch(Exception exAttach)
 			{
-				Toast.MakeText(this, GetString(Resource.String.AttachFailed)+" "+exAttach.Message, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, GetString(Resource.String.AttachFailed)+" "+exAttach.Message,  MessageSeverity.Error);
 			}
 			State.EntryModified = true;
 			PopulateBinaries();
@@ -833,7 +833,7 @@ namespace keepass2android
 						string s = Util.GetFilenameFromInternalFileChooser(data, this);
 						if (s == null)
 						{
-							Toast.MakeText(this, "No URI retrieved.", ToastLength.Short).Show();
+							App.Kp2a.ShowMessage(this, "No URI retrieved.",  MessageSeverity.Error);
 							return;
 						}
 						uri = Uri.Parse(s);
@@ -1139,7 +1139,7 @@ namespace keepass2android
 				}
                 else
                 {
-					Toast.MakeText(this, "did not find target field", ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(this, "did not find target field",  MessageSeverity.Error);
                 }
                 
 				
@@ -1158,7 +1158,8 @@ namespace keepass2android
             {
                 if (GoogleApiAvailability.Instance.IsGooglePlayServicesAvailable(this) != ConnectionResult.Success)
                 {
-                    Toast.MakeText(this, Resource.String.qr_scanning_error_no_google_play_services, ToastLength.Long);
+                    App.Kp2a.ShowMessage(this, Resource.String.qr_scanning_error_no_google_play_services,
+                        MessageSeverity.Error);
                     return;
                 }
 
@@ -1178,7 +1179,7 @@ namespace keepass2android
                         }
                         else
                         {
-                            Toast.MakeText(this, "Scanned code should contain an otpauth:// text.", ToastLength.Long).Show();
+                            App.Kp2a.ShowMessage(this, "Scanned code should contain an otpauth:// text.",  MessageSeverity.Warning);
                         }
                     }))
                     .AddOnFailureListener(new FailureListener((e) =>
@@ -1503,7 +1504,7 @@ namespace keepass2android
 			// Require title
 			String title = Util.GetEditText(this, Resource.Id.entry_title);
 			if ( title.Length == 0 ) {
-				Toast.MakeText(this, Resource.String.error_title_required, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, Resource.String.error_title_required,  MessageSeverity.Error);
 				return false;
 			}
 			
@@ -1513,7 +1514,7 @@ namespace keepass2android
 			DateTime newExpiry = new DateTime();
 			if ((State.Entry.Expires) && (!DateTime.TryParse( Util.GetEditText(this,Resource.Id.entry_expires), out newExpiry)))
 		    {
-				Toast.MakeText(this, Resource.String.error_invalid_expiry_date, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, Resource.String.error_invalid_expiry_date,  MessageSeverity.Error);
 				return false;
 			}
 			State.Entry.ExpiryTime = newExpiry.ToUniversalTime();
@@ -1527,13 +1528,13 @@ namespace keepass2android
 				string key = keyView.Text;
 				
 				if (String.IsNullOrEmpty(key)) {
-					Toast.MakeText(this, Resource.String.error_string_key, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(this, Resource.String.error_string_key,  MessageSeverity.Error);
 					return false;
 				}
 
 				if (allKeys.Contains(key))
 				{
-					Toast.MakeText(this, GetString(Resource.String.error_string_duplicate_key, new Object[]{key}), ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(this, GetString(Resource.String.error_string_duplicate_key, new Object[]{key}),  MessageSeverity.Error);
 					return false;
 				}
 

--- a/src/keepass2android-app/ExportDatabaseActivity.cs
+++ b/src/keepass2android-app/ExportDatabaseActivity.cs
@@ -29,9 +29,9 @@ namespace keepass2android
             var exportDb = new ExportDatabaseActivity.ExportDb(_activity, App.Kp2a, new ActionOnFinish(_activity, (success, message, activity) =>
                 {
                     if (!success)
-                        Toast.MakeText(activity, message, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                     else
-                        Toast.MakeText(activity, _activity.GetString(Resource.String.export_database_successful), ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(activity, _activity.GetString(Resource.String.export_database_successful),  MessageSeverity.Info);
                     activity.Finish();
                 }
             ), _ffp, ioc);

--- a/src/keepass2android-app/FileSaveProcessManager.cs
+++ b/src/keepass2android-app/FileSaveProcessManager.cs
@@ -107,7 +107,7 @@ namespace keepass2android
                             {
                                 if (!success)
                                 {
-                                    Toast.MakeText(activity, messageOrFilename, ToastLength.Long).Show();
+                                    App.Kp2a.ShowMessage(activity, messageOrFilename,  MessageSeverity.Error);
                                     return;
                                 }
                                 SaveFile(new IOConnectionInfo { Path = FileSelectHelper.ConvertFilenameToIocPath(messageOrFilename) });

--- a/src/keepass2android-app/FileSelectHelper.cs
+++ b/src/keepass2android-app/FileSelectHelper.cs
@@ -115,6 +115,7 @@ namespace keepass2android
 				string keyContent = keyContentTxt.Text;
 
 				string toastMsg = null;
+				MessageSeverity severity = MessageSeverity.Info;
                 if (!string.IsNullOrEmpty(keyName) && !string.IsNullOrEmpty(keyContent))
 				{
 					try
@@ -128,7 +129,9 @@ namespace keepass2android
 					{
 						toastMsg = ctx.GetString(Resource.String.private_key_save_failed,
 							new Java.Lang.Object[] { e.Message });
-					}
+                        severity = MessageSeverity.Error;
+
+                    }
 				}
 				else
 				{
@@ -136,7 +139,7 @@ namespace keepass2android
 				}
 
 				if (toastMsg!= null) {
-                    Toast.MakeText(_activity, toastMsg, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(_activity, toastMsg,  severity);
                 }
 
 				UpdatePrivateKeyNames(keyNamesAdapter, fileStorage, ctx);
@@ -153,7 +156,7 @@ namespace keepass2android
 
 					int msgId = deleted ? Resource.String.private_key_delete : Resource.String.private_key_delete_failed;
 					string msg = ctx.GetString(msgId, new Java.Lang.Object[] { keyName });
-                    Toast.MakeText(_activity, msg, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(_activity, msg,  deleted ? MessageSeverity.Info :MessageSeverity.Error);
 
 					UpdatePrivateKeyNames(keyNamesAdapter, fileStorage, ctx);
 					keySpinner.SetSelection(SftpKeySpinnerCreateNewIdx);
@@ -581,9 +584,9 @@ namespace keepass2android
 			// Make sure file name exists
 			if (filename.Length == 0)
 			{
-				Toast.MakeText(_activity,
+				App.Kp2a.ShowMessage(_activity,
 								Resource.String.error_filename_required,
-								ToastLength.Long).Show();
+								 MessageSeverity.Error);
 				return false;
 			}
 
@@ -604,9 +607,9 @@ namespace keepass2android
 			}
 			catch (NoFileStorageFoundException)
 			{
-				Toast.MakeText(_activity,
+				App.Kp2a.ShowMessage(_activity,
 								"Unexpected scheme in "+filename,
-								ToastLength.Long).Show();
+								 MessageSeverity.Error);
 				return false;
 			}
 
@@ -620,9 +623,9 @@ namespace keepass2android
 
 					if (parent == null || (parent.Exists() && !parent.IsDirectory))
 					{
-						Toast.MakeText(_activity,
+						App.Kp2a.ShowMessage(_activity,
 							            Resource.String.error_invalid_path,
-							            ToastLength.Long).Show();
+							             MessageSeverity.Error);
 						return false;
 					}
 
@@ -631,9 +634,9 @@ namespace keepass2android
 						// Create parent dircetory
 						if (!parent.Mkdirs())
 						{
-							Toast.MakeText(_activity,
+							App.Kp2a.ShowMessage(_activity,
 								            Resource.String.error_could_not_create_parent,
-								            ToastLength.Long).Show();
+								             MessageSeverity.Error);
 							return false;
 
 						}
@@ -643,11 +646,11 @@ namespace keepass2android
 				}
 				catch (Java.IO.IOException ex)
 				{
-					Toast.MakeText(
+					App.Kp2a.ShowMessage(
 						_activity,
 						_activity.GetText(Resource.String.error_file_not_create) + " "
 						+ ex.LocalizedMessage,
-						ToastLength.Long).Show();
+						 MessageSeverity.Error);
 					return false;
 				}
 
@@ -700,7 +703,7 @@ namespace keepass2android
 			_activity.StartActivityForResult(i, _requestCode);
 
 #else
-			Toast.MakeText(LocaleManager.LocalizedAppContext, "File chooser is excluded!", ToastLength.Long).Show();
+			App.Kp2a.ShowMessage(LocaleManager.LocalizedAppContext, "File chooser is excluded!",  MessageSeverity.Error);
 #endif
 			return true;
 		}
@@ -782,7 +785,7 @@ namespace keepass2android
 							{
 								if (!success)
 								{
-									Toast.MakeText(newActivity, messageOrFilename, ToastLength.Long).Show();
+									App.Kp2a.ShowMessage(newActivity, messageOrFilename,  MessageSeverity.Error);
 									return;
 								}
 								var ioc = new IOConnectionInfo { Path = ConvertFilenameToIocPath(messageOrFilename) };

--- a/src/keepass2android-app/FingerprintSetupActivity.cs
+++ b/src/keepass2android-app/FingerprintSetupActivity.cs
@@ -251,7 +251,7 @@ namespace keepass2android
 			catch (Exception e)
 			{
 				CheckCurrentRadioButton();
-				Toast.MakeText(this, e.ToString(), ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, e.ToString(),  MessageSeverity.Error);
 				FindViewById(Resource.Id.radio_buttons).Visibility = ViewStates.Visible;
 				FindViewById(Resource.Id.fingerprint_auth_container).Visibility = ViewStates.Gone;
 			}

--- a/src/keepass2android-app/GeneratePasswordActivity.cs
+++ b/src/keepass2android-app/GeneratePasswordActivity.cs
@@ -543,7 +543,7 @@ namespace keepass2android
             }
             catch (Exception e) 
             {
-				Toast.MakeText(this, e.Message, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, e.Message,  MessageSeverity.Error);
 			}
 			
 			return password;

--- a/src/keepass2android-app/GroupBaseActivity.cs
+++ b/src/keepass2android-app/GroupBaseActivity.cs
@@ -56,6 +56,8 @@ namespace keepass2android
 
         public const int RequestCodeActivateRealSearch = 12366;
 
+        protected override View? SnackbarAnchorView => FindViewById(Resource.Id.main_content);
+
         static readonly Dictionary<int /*resource id*/, int /*prio*/> bottomBarElementsPriority = new Dictionary<int, int>()
         {
             { Resource.Id.cancel_insert_element, 20 },
@@ -927,7 +929,7 @@ namespace keepass2android
                 {
                     ((GroupBaseActivity)activity)?.StopMovingElements();
                     if (!String.IsNullOrEmpty(message))
-                        Toast.MakeText(activity, message, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                 }));
             var progressTask = new ProgressTask(App.Kp2a, this, moveElement);
             progressTask.Run();
@@ -1328,7 +1330,7 @@ namespace keepass2android
                 {
                     Handler.Post(() =>
                     {
-                        Toast.MakeText(ActiveActivity ?? LocaleManager.LocalizedAppContext, "Unrecoverable error: " + Message, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(ActiveActivity ?? LocaleManager.LocalizedAppContext, "Unrecoverable error: " + Message,  MessageSeverity.Error);
                     });
 
                     App.Kp2a.Lock(false);

--- a/src/keepass2android-app/GroupEditActivity.cs
+++ b/src/keepass2android-app/GroupEditActivity.cs
@@ -111,9 +111,10 @@ namespace keepass2android
 					SetResult (Result.Ok, intent);
 					
 					Finish ();
-				} else {
-					Toast.MakeText (this, Resource.String.error_no_name, ToastLength.Long).Show ();
-				}
+				} else
+                {
+                    App.Kp2a.ShowMessage(this, Resource.String.error_no_name, MessageSeverity.Error);
+                }
 			};
 
 			if (Intent.HasExtra(KeyGroupUuid))

--- a/src/keepass2android-app/KeeAutoExec.cs
+++ b/src/keepass2android-app/KeeAutoExec.cs
@@ -316,7 +316,7 @@ namespace keepass2android
                 try { ck.AddUserKey(new KcpKeyFile(strAbs)); }
                 catch (InvalidOperationException)
                 {
-                    Toast.MakeText(LocaleManager.LocalizedAppContext,Resource.String.error_adding_keyfile,ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(LocaleManager.LocalizedAppContext,Resource.String.error_adding_keyfile, MessageSeverity.Error);
                     return false;
                 }
                 catch (Exception) { throw; }

--- a/src/keepass2android-app/LockingActivity.cs
+++ b/src/keepass2android-app/LockingActivity.cs
@@ -21,8 +21,10 @@ using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.Runtime;
+using Android.Views;
 using Google.Android.Material.Dialog;
 using keepass2android;
+using keepass2android.Utils;
 
 namespace keepass2android
 {
@@ -76,19 +78,34 @@ namespace keepass2android
 			base.OnPause();
 			
 			TimeoutHelper.Pause(this);
-		}
+			App.Kp2a.MessagePresenter = new NonePresenter();
+        }
 
 		protected override void OnDestroy()
 		{
 			base.OnDestroy();
 			GC.Collect();
 		}
-		
-		protected override void OnResume() {
-			base.OnResume();
-			
-			TimeoutHelper.Resume(this);
-		}
+
+        protected override void OnResume()
+        {
+            base.OnResume();
+
+            TimeoutHelper.Resume(this);
+            var snackbarAnchorView = SnackbarAnchorView;
+            if (snackbarAnchorView != null)
+            {
+                App.Kp2a.MessagePresenter = new ChainedSnackbarPresenter(snackbarAnchorView);
+            }
+            else
+            {
+                App.Kp2a.MessagePresenter = new ToastPresenter();
+            }
+        }
+
+
+        protected virtual View? SnackbarAnchorView => null;
+    
 
 	    public const int RequestCodeChallengeYubikey = 793;
 

--- a/src/keepass2android-app/NfcOtpActivity.cs
+++ b/src/keepass2android-app/NfcOtpActivity.cs
@@ -145,7 +145,7 @@ namespace keepass2android
 			catch (Exception e)
 			{
 				Kp2aLog.LogUnexpectedError(e);
-				Toast.MakeText(this, "No Yubikey OTP found!", ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, "No Yubikey OTP found!",  MessageSeverity.Error);
 				Finish();
 				return;
 			}

--- a/src/keepass2android-app/QueryCredentialsActivity.cs
+++ b/src/keepass2android-app/QueryCredentialsActivity.cs
@@ -128,11 +128,11 @@ namespace keepass2android
 				Kp2aLog.LogUnexpectedError(e);
 			}
 			if (String.IsNullOrEmpty(_requestedUrl))
-				Toast.MakeText(this, GetString(Resource.String.query_credentials, new Java.Lang.Object[] {pluginDisplayName}), ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, GetString(Resource.String.query_credentials, new Java.Lang.Object[] {pluginDisplayName}),  MessageSeverity.Info);
 			else
-				Toast.MakeText(this,
+				App.Kp2a.ShowMessage(this,
 				               GetString(Resource.String.query_credentials_for_url,
-										 new Java.Lang.Object[] { pluginDisplayName, _requestedUrl }), ToastLength.Long).Show(); ;
+										 new Java.Lang.Object[] { pluginDisplayName, _requestedUrl }),  MessageSeverity.Info); ;
 		}
 
 		private void StartQuery()

--- a/src/keepass2android-app/QuickUnlock.cs
+++ b/src/keepass2android-app/QuickUnlock.cs
@@ -35,6 +35,7 @@ using KeePassLib;
 using KeePassLib.Serialization;
 using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
 using AndroidX.Core.Content;
+using keepass2android.Utils;
 
 namespace keepass2android
 {
@@ -203,7 +204,7 @@ namespace keepass2android
 				btn.SetImageResource(Resource.Drawable.baseline_fingerprint_24);
 				
 			}, 1300);
-			Toast.MakeText(this, message, ToastLength.Long).Show();
+			App.Kp2a.ShowMessage(this, message,  MessageSeverity.Error);
 		}
 
         
@@ -325,7 +326,7 @@ namespace keepass2android
 			{
 				Kp2aLog.Log("QuickUnlock not successful!");
 				App.Kp2a.Lock(false);
-				Toast.MakeText(this, GetString(Resource.String.QuickUnlock_fail), ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, GetString(Resource.String.QuickUnlock_fail),  MessageSeverity.Error);
                 Finish();
 			}
 			
@@ -383,8 +384,9 @@ namespace keepass2android
 		{
 			base.OnResume();
 			_design.ReapplyTheme();
-			
-			CheckIfUnloaded();
+            App.Kp2a.MessagePresenter = new ChainedSnackbarPresenter(FindViewById(Resource.Id.main_content));
+
+            CheckIfUnloaded();
 
             InitFingerprintUnlock();
 
@@ -449,7 +451,8 @@ namespace keepass2android
 
 		protected override void OnPause()
 		{
-			if (_biometryIdentifier != null)
+            App.Kp2a.MessagePresenter = new NonePresenter();
+            if (_biometryIdentifier != null)
 			{
 				Kp2aLog.Log("FP: Stop listening");
 				_biometryIdentifier.StopListening();

--- a/src/keepass2android-app/Resources/layout/entry_edit.xml
+++ b/src/keepass2android-app/Resources/layout/entry_edit.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                     android:id="@+id/main_content"
+                                                     android:layout_width="match_parent"
+                                                     android:layout_height="match_parent"
+                                                     android:fitsSystemWindows="true">
+
+<ScrollView 
             xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/entry_scroll"
     android:background="?android:attr/colorBackground"
@@ -268,3 +274,4 @@
         </LinearLayout>
     </LinearLayout>
 </ScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/keepass2android-app/SelectCurrentDbActivity.cs
+++ b/src/keepass2android-app/SelectCurrentDbActivity.cs
@@ -392,7 +392,7 @@ namespace keepass2android
                 if (ioc.Path.Length == 0)
                 {
                     // No file name
-                    Toast.MakeText(this, Resource.String.FileNotFound, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(this, Resource.String.FileNotFound,  MessageSeverity.Error);
                     return false;
                 }
 
@@ -400,7 +400,7 @@ namespace keepass2android
                 if (!dbFile.Exists())
                 {
                     // File does not exist
-                    Toast.MakeText(this, Resource.String.FileNotFound, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(this, Resource.String.FileNotFound,  MessageSeverity.Error);
                     return false;
                 }
             }
@@ -408,7 +408,7 @@ namespace keepass2android
             {
                 if (!ioc.Path.StartsWith("content://"))
                 {
-                    Toast.MakeText(this, Resource.String.error_can_not_handle_uri, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(this, Resource.String.error_can_not_handle_uri,  MessageSeverity.Error);
                     return false;
                 }
                 IoUtil.TryTakePersistablePermissions(this.ContentResolver, intent.Data);
@@ -468,7 +468,7 @@ namespace keepass2android
                     }
                     catch (Exception e)
                     {
-                        Toast.MakeText(this, "Failed to open child databases",ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(this, "Failed to open child databases", MessageSeverity.Error);
                         Kp2aLog.LogUnexpectedError(e);
                     }
                     

--- a/src/keepass2android-app/SelectStorageLocationActivity.cs
+++ b/src/keepass2android-app/SelectStorageLocationActivity.cs
@@ -70,15 +70,15 @@ namespace keepass2android
 
 		protected Bundle State { get; set; }
 
-		protected override void ShowToast(string text)
+		protected override void ShowErrorToast(string text)
 		{
-			Toast.MakeText(this, text, ToastLength.Long).Show();
+			App.Kp2a.ShowMessage(this, text,  MessageSeverity.Error);
 		}
 
 		protected override void ShowInvalidSchemeMessage(string dataString)
 		{
-			Toast.MakeText(this, Resources.GetString(Resource.String.unknown_uri_scheme, new Java.Lang.Object[] { dataString }),
-										   ToastLength.Long).Show();
+			App.Kp2a.ShowMessage(this, Resources.GetString(Resource.String.unknown_uri_scheme, new Java.Lang.Object[] { dataString }),
+										    MessageSeverity.Error);
 		}
 
 		protected override string IntentToFilename(Intent data)
@@ -194,7 +194,7 @@ namespace keepass2android
 
 			StartActivityForResult(intent, requestCode);
 			#else
-			Toast.MakeText(this, "File chooser is excluded!", ToastLength.Long).Show();
+			App.Kp2a.ShowMessage(this, "File chooser is excluded!",  MessageSeverity.Error);
 			#endif
 		}
 

--- a/src/keepass2android-app/SetPasswordDialog.cs
+++ b/src/keepass2android-app/SetPasswordDialog.cs
@@ -57,7 +57,7 @@ namespace keepass2android
 				// Verify that passwords match
 				if ( ! pass.Equals(confpass) ) {
 					// Passwords do not match
-					Toast.MakeText(Context, Resource.String.error_pass_match, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(Context, Resource.String.error_pass_match,  MessageSeverity.Error);
 					return;
 				}
 				
@@ -67,7 +67,7 @@ namespace keepass2android
 				
 				// Verify that a password or keyfile is set
 				if ( pass.Length == 0 && keyfile.Length == 0 ) {
-					Toast.MakeText(Context, Resource.String.error_nopass, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(Context, Resource.String.error_nopass,  MessageSeverity.Error);
 					return;
 					
 				}
@@ -114,7 +114,7 @@ namespace keepass2android
 						edit.PutString(App.Kp2a.CurrentDb.CurrentFingerprintModePrefKey, FingerprintUnlockMode.Disabled.ToString());
 						edit.Commit();
 
-						Toast.MakeText(_dlg.Context, Resource.String.fingerprint_reenable, ToastLength.Long).Show();
+						App.Kp2a.ShowMessage(_dlg.Context, Resource.String.fingerprint_reenable,  MessageSeverity.Warning);
 						_dlg.Context.StartActivity(typeof(BiometricSetupActivity));
 					}
 

--- a/src/keepass2android-app/ShareUrlResults.cs
+++ b/src/keepass2android-app/ShareUrlResults.cs
@@ -121,7 +121,7 @@ namespace keepass2android
                 
             } catch (Exception e)
 			{
-				Toast.MakeText(this, e.Message, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this, e.Message,  MessageSeverity.Error);
 				SetResult(Result.Canceled);
 				Finish();
 				return;
@@ -184,7 +184,7 @@ namespace keepass2android
                     createUrlEntry.Click += (sender, e) =>
                     {
                         GroupActivity.Launch(this, new CreateEntryThenCloseTask { Url = searchUrl, ShowUserNotifications = (AppTask as SelectEntryTask)?.ShowUserNotifications ?? ActivationCondition.Always }, new ActivityLaunchModeRequestCode(0));
-                        Toast.MakeText(this, GetString(Resource.String.select_group_then_add, new Java.Lang.Object[] { GetString(Resource.String.add_entry) }), ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(this, GetString(Resource.String.select_group_then_add, new Java.Lang.Object[] { GetString(Resource.String.add_entry) }),  MessageSeverity.Info);
                     };
                 }
                 else

--- a/src/keepass2android-app/SyncUtil.cs
+++ b/src/keepass2android-app/SyncUtil.cs
@@ -56,7 +56,7 @@ namespace keepass2android
             OnFinish onFinish = new ActionOnFinish(_activity, (success, message, activity) =>
             {
                 if (!String.IsNullOrEmpty(message))
-                    Toast.MakeText(activity, message, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
 
                 // Tell the adapter to refresh it's list
                 BaseAdapter adapter = (activity as GroupBaseActivity)?.ListAdapter;

--- a/src/keepass2android-app/Totp/TrayTotpPluginAdapter.cs
+++ b/src/keepass2android-app/Totp/TrayTotpPluginAdapter.cs
@@ -161,7 +161,7 @@ namespace PluginTOTP
 					return;
 				try
 				{
-					_uiThreadHandler.Post(() => Toast.MakeText(_ctx, warning, ToastLength.Short).Show());
+					_uiThreadHandler.Post(() => App.Kp2a.ShowMessage(_ctx, warning,  MessageSeverity.Warning));
 				}
 				catch (Exception e)
 				{

--- a/src/keepass2android-app/Utils/MessagePresenter.cs
+++ b/src/keepass2android-app/Utils/MessagePresenter.cs
@@ -78,7 +78,15 @@ namespace keepass2android.Utils
 
                 if (!queuedMessages.Any())
                 {
-                    new Handler().PostDelayed(() => { ShowNextSnackbar(); }, (long)waitDuration.TotalMilliseconds);
+                    if (Looper.MainLooper != null)
+                    {
+                        new Handler(Looper.MainLooper).PostDelayed(ShowNextSnackbar,
+                            (long)waitDuration.TotalMilliseconds);
+                    }
+                    else
+                    {
+                        Kp2aLog.Log("Currently cannot show message");
+                    }
                 }
                 
                 queuedMessages.Add(message);

--- a/src/keepass2android-app/Utils/MessagePresenter.cs
+++ b/src/keepass2android-app/Utils/MessagePresenter.cs
@@ -71,16 +71,17 @@ namespace keepass2android.Utils
 
         public void ShowMessage(Message message)
         {
-            if (DateTime.Now < nextSnackbarShowTime)
+            if (DateTime.Now <= nextSnackbarShowTime)
             {
                 var waitDuration = nextSnackbarShowTime - DateTime.Now;
                 nextSnackbarShowTime = nextSnackbarShowTime.Add(chainingTime);
-                
-                new Handler().PostDelayed(() => { ShowNextSnackbar(); }, (long)waitDuration.TotalMilliseconds);
-                if (queuedMessages.Any())
+
+                if (!queuedMessages.Any())
                 {
-                    queuedMessages.Add(message);
+                    new Handler().PostDelayed(() => { ShowNextSnackbar(); }, (long)waitDuration.TotalMilliseconds);
                 }
+                
+                queuedMessages.Add(message);
 
                 return;
             }

--- a/src/keepass2android-app/Utils/MessagePresenter.cs
+++ b/src/keepass2android-app/Utils/MessagePresenter.cs
@@ -1,0 +1,153 @@
+﻿using Android.OS;
+using Android.Views;
+using Google.Android.Material.Snackbar;
+
+namespace keepass2android.Utils
+{
+    public struct Message
+    {
+        public Message()
+        {
+            Text = null;
+            Severity = MessageSeverity.Info;
+        }
+
+        public string Text { get; set; }
+        public MessageSeverity Severity { get; set; }
+        public bool ShowOnSubsequentScreens { get; set; } = true;
+    }
+    public interface IMessagePresenter
+    {
+        void ShowMessage(Message message);
+
+        List<Message> PendingMessages
+        {
+            get;
+        }
+
+    }
+
+    internal class NonePresenter : IMessagePresenter
+    {
+        public void ShowMessage(Message message)
+        {
+            PendingMessages.Add(message);
+        }
+
+        public List<Message> PendingMessages
+        {
+            get;
+            set;
+        } = new List<Message>();
+    }
+
+
+    internal class ToastPresenter : IMessagePresenter
+    {
+        public void ShowMessage(Message message)
+        {
+            Toast.MakeText(App.Context, message.Text, ToastLength.Long).Show();
+        }
+
+        public List<Message> PendingMessages => new();
+    }
+
+    internal class ChainedSnackbarPresenter: IMessagePresenter
+    {
+        internal ChainedSnackbarPresenter(View anchorView)
+        {
+            this.AnchorView = anchorView;
+            
+        }
+
+        private DateTime nextSnackbarShowTime = DateTime.Now;
+        private List<Message> queuedMessages = new List<Message>();
+
+        public View AnchorView { get; set; }
+
+        private TimeSpan chainingTime = TimeSpan.FromSeconds(1.5);
+        private Snackbar snackbar;
+        private Message lastMessage;
+
+        public void ShowMessage(Message message)
+        {
+            if (DateTime.Now < nextSnackbarShowTime)
+            {
+                var waitDuration = nextSnackbarShowTime - DateTime.Now;
+                nextSnackbarShowTime = nextSnackbarShowTime.Add(chainingTime);
+                
+                new Handler().PostDelayed(() => { ShowNextSnackbar(); }, (long)waitDuration.TotalMilliseconds);
+                if (queuedMessages.Any())
+                {
+                    queuedMessages.Add(message);
+                }
+
+                return;
+            }
+            ShowSnackbarNow(message);
+            nextSnackbarShowTime = DateTime.Now.Add(chainingTime);
+
+        }
+
+        public List<Message> PendingMessages
+        {
+            get
+            {
+                List<Message> pendingMessages = new List<Message>();
+                if (snackbar?.IsShown == true)
+                {
+                    pendingMessages.Add(lastMessage);
+                }
+
+                pendingMessages.AddRange(queuedMessages);
+                return pendingMessages;
+            }
+        }
+
+        private void ShowNextSnackbar()
+        {
+            if (!queuedMessages.Any())
+            {
+                return;
+            }
+
+            ShowSnackbarNow(queuedMessages.First());
+            queuedMessages.RemoveAt(0);
+
+            if (!queuedMessages.Any())
+            {
+                new Handler().PostDelayed(() => { ShowNextSnackbar(); }, (long)chainingTime.TotalMilliseconds);
+            }
+        }
+
+        private void ShowSnackbarNow(Message message)
+        {
+            snackbar = Snackbar
+                .Make(AnchorView, message.Text,
+                    Snackbar.LengthLong);
+            snackbar.SetTextMaxLines(10);
+            if ((int)Build.VERSION.SdkInt >= 23)
+            {
+                if (message.Severity == MessageSeverity.Error)
+                {
+                    snackbar.SetBackgroundTint(App.Context.GetColor(Resource.Color.md_theme_errorContainer));
+                    snackbar.SetTextColor(App.Context.GetColor(Resource.Color.md_theme_onErrorContainer));
+                }
+                else if (message.Severity == MessageSeverity.Warning)
+                {
+                    snackbar.SetBackgroundTint(App.Context.GetColor(Resource.Color.md_theme_inverseSurface));
+                    snackbar.SetTextColor(App.Context.GetColor(Resource.Color.md_theme_inverseOnSurface));
+                }
+                else
+                {
+                    snackbar.SetBackgroundTint(App.Context.GetColor(Resource.Color.md_theme_secondaryContainer));
+                    snackbar.SetTextColor(App.Context.GetColor(Resource.Color.md_theme_onSecondaryContainer));
+                }
+            }
+
+            snackbar.Show();
+            lastMessage = message;
+
+        }
+    }
+}

--- a/src/keepass2android-app/Utils/Util.cs
+++ b/src/keepass2android-app/Utils/Util.cs
@@ -172,289 +172,311 @@ namespace keepass2android
     }
 
 
-    public class Util {
-
-		
-		public const String KeyFilename = "fileName";
-	    public const String KeyServerusername = "serverCredUser";
-	    public const String KeyServerpassword = "serverCredPwd";
-	    public const String KeyServercredmode = "serverCredRememberMode";
+    public class Util
+    {
 
 
-        public static void PutIoConnectionToIntent(IOConnectionInfo ioc, Intent i, string prefix="")
-	    {
-	        i.PutExtra(prefix+KeyFilename, ioc.Path);
-	        i.PutExtra(prefix + KeyServerusername, ioc.UserName);
-	        i.PutExtra(prefix + KeyServerpassword, ioc.Password);
-	        i.PutExtra(prefix + KeyServercredmode, (int)ioc.CredSaveMode);
-	    }
+        public const String KeyFilename = "fileName";
+        public const String KeyServerusername = "serverCredUser";
+        public const String KeyServerpassword = "serverCredPwd";
+        public const String KeyServercredmode = "serverCredRememberMode";
 
-	    public static void SetIoConnectionFromIntent(IOConnectionInfo ioc, Intent i, string prefix="")
-	    {
-	        ioc.Path = i.GetStringExtra(prefix + KeyFilename);
-	        ioc.UserName = i.GetStringExtra(prefix + KeyServerusername) ?? "";
-	        ioc.Password = i.GetStringExtra(prefix + KeyServerpassword) ?? "";
-	        ioc.CredSaveMode = (IOCredSaveMode)i.GetIntExtra(prefix + KeyServercredmode, (int)IOCredSaveMode.NoSave);
-	    }
+
+        public static void PutIoConnectionToIntent(IOConnectionInfo ioc, Intent i, string prefix = "")
+        {
+            i.PutExtra(prefix + KeyFilename, ioc.Path);
+            i.PutExtra(prefix + KeyServerusername, ioc.UserName);
+            i.PutExtra(prefix + KeyServerpassword, ioc.Password);
+            i.PutExtra(prefix + KeyServercredmode, (int)ioc.CredSaveMode);
+        }
+
+        public static void SetIoConnectionFromIntent(IOConnectionInfo ioc, Intent i, string prefix = "")
+        {
+            ioc.Path = i.GetStringExtra(prefix + KeyFilename);
+            ioc.UserName = i.GetStringExtra(prefix + KeyServerusername) ?? "";
+            ioc.Password = i.GetStringExtra(prefix + KeyServerpassword) ?? "";
+            ioc.CredSaveMode = (IOCredSaveMode)i.GetIntExtra(prefix + KeyServercredmode, (int)IOCredSaveMode.NoSave);
+        }
 
         public static Bitmap DrawableToBitmap(Drawable drawable)
-		{
-			Bitmap bitmap = null;
+        {
+            Bitmap bitmap = null;
 
-			if (drawable is BitmapDrawable)
-			{
-				BitmapDrawable bitmapDrawable = (BitmapDrawable)drawable;
-				if (bitmapDrawable.Bitmap != null)
-				{
-					return bitmapDrawable.Bitmap;
-				}
-			}
+            if (drawable is BitmapDrawable)
+            {
+                BitmapDrawable bitmapDrawable = (BitmapDrawable)drawable;
+                if (bitmapDrawable.Bitmap != null)
+                {
+                    return bitmapDrawable.Bitmap;
+                }
+            }
 
-			if (drawable.IntrinsicWidth <= 0 || drawable.IntrinsicHeight <= 0)
-			{
-				bitmap = Bitmap.CreateBitmap(1, 1, Bitmap.Config.Argb8888); // Single color bitmap will be created of 1x1 pixel
-			}
-			else
-			{
-				bitmap = Bitmap.CreateBitmap(drawable.IntrinsicWidth, drawable.IntrinsicHeight, Bitmap.Config.Argb8888);
-			}
+            if (drawable.IntrinsicWidth <= 0 || drawable.IntrinsicHeight <= 0)
+            {
+                bitmap = Bitmap.CreateBitmap(1, 1,
+                    Bitmap.Config.Argb8888); // Single color bitmap will be created of 1x1 pixel
+            }
+            else
+            {
+                bitmap = Bitmap.CreateBitmap(drawable.IntrinsicWidth, drawable.IntrinsicHeight, Bitmap.Config.Argb8888);
+            }
 
-			Canvas canvas = new Canvas(bitmap);
-			drawable.SetBounds(0, 0, canvas.Width, canvas.Height);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.SetBounds(0, 0, canvas.Width, canvas.Height);
 
             drawable.Draw(canvas);
 
-		    
+
 
             return bitmap;
-		}
+        }
 
-	    public static Bitmap ChangeImageColor(Bitmap sourceBitmap, Color color)
-	    {
-	        Bitmap temp = Bitmap.CreateBitmap(sourceBitmap, 0, 0,
-	            sourceBitmap.Width, sourceBitmap.Height);
-	        Bitmap resultBitmap = temp.Copy(Bitmap.Config.Argb8888, true);
+        public static Bitmap ChangeImageColor(Bitmap sourceBitmap, Color color)
+        {
+            Bitmap temp = Bitmap.CreateBitmap(sourceBitmap, 0, 0,
+                sourceBitmap.Width, sourceBitmap.Height);
+            Bitmap resultBitmap = temp.Copy(Bitmap.Config.Argb8888, true);
             Paint p = new Paint();
-	        ColorFilter filter = new LightingColorFilter(color.ToArgb(), 0);
-	        p.SetColorFilter(filter);
+            ColorFilter filter = new LightingColorFilter(color.ToArgb(), 0);
+            p.SetColorFilter(filter);
 
-	        Canvas canvas = new Canvas(resultBitmap);
-	        canvas.DrawBitmap(resultBitmap, 0, 0, p);
-	        return resultBitmap;
-	    }
+            Canvas canvas = new Canvas(resultBitmap);
+            canvas.DrawBitmap(resultBitmap, 0, 0, p);
+            return resultBitmap;
+        }
 
 
         public static float convertDpToPixel(float dp, Context context)
-		{
-			Resources resources = context.Resources;
-			DisplayMetrics metrics = resources.DisplayMetrics;
-			float px = dp * metrics.Density;
-			return px;
-		}
-		public static String GetClipboard(Context context)
         {
-            Android.Content.ClipboardManager clipboardManager = (ClipboardManager)context.GetSystemService(Context.ClipboardService);
+            Resources resources = context.Resources;
+            DisplayMetrics metrics = resources.DisplayMetrics;
+            float px = dp * metrics.Density;
+            return px;
+        }
+
+        public static String GetClipboard(Context context)
+        {
+            Android.Content.ClipboardManager clipboardManager =
+                (ClipboardManager)context.GetSystemService(Context.ClipboardService);
             var clip = clipboardManager.PrimaryClip;
             if (clip != null && clip.ItemCount > 0)
             {
                 return clip.GetItemAt(0).CoerceToText(context);
             }
+
             return "";
         }
-		
-		public static void CopyToClipboard(Context context, String text, bool isProtected) {
-            Android.Content.ClipboardManager clipboardManager = (ClipboardManager)context.GetSystemService(Context.ClipboardService);
-            ClipData clipData = Android.Content.ClipData.NewPlainText("KP2A", text);
-			if (isProtected)
-			{
-				//ClipDescription.Extras is only available since 24 
-				if ((int) Build.VERSION.SdkInt >= 24)
-				{
-					var extras = clipData.Description.Extras ?? new Android.OS.PersistableBundle();
-					extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
-					clipData.Description.Extras = extras;
-				}
-			}
-            clipboardManager.PrimaryClip = clipData;
-		    if (text == "")
-		    {
-                //on some devices, adding empty text does not seem to work. Try again with some garbage.
-		        clipData = Android.Content.ClipData.NewPlainText("KP2A", "***");
-		        clipboardManager.PrimaryClip = clipData;
-                //seems to work better on some devices:
-		        try
-		        {
-		            clipboardManager.Text = text;
-                }
-		        catch (Exception exception)
-		        {
-		            Kp2aLog.LogUnexpectedError(exception);
 
-		        }
-		        
+        public static void CopyToClipboard(Context context, String text, bool isProtected)
+        {
+            Android.Content.ClipboardManager clipboardManager =
+                (ClipboardManager)context.GetSystemService(Context.ClipboardService);
+            ClipData clipData = Android.Content.ClipData.NewPlainText("KP2A", text);
+            if (isProtected)
+            {
+                //ClipDescription.Extras is only available since 24 
+                if ((int)Build.VERSION.SdkInt >= 24)
+                {
+                    var extras = clipData.Description.Extras ?? new Android.OS.PersistableBundle();
+                    extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
+                    clipData.Description.Extras = extras;
+                }
+            }
+
+            clipboardManager.PrimaryClip = clipData;
+            if (text == "")
+            {
+                //on some devices, adding empty text does not seem to work. Try again with some garbage.
+                clipData = Android.Content.ClipData.NewPlainText("KP2A", "***");
+                clipboardManager.PrimaryClip = clipData;
+                //seems to work better on some devices:
+                try
+                {
+                    clipboardManager.Text = text;
+                }
+                catch (Exception exception)
+                {
+                    Kp2aLog.LogUnexpectedError(exception);
+
+                }
+
             }
 
 
         }
 
-	    private static readonly Regex ARC_DEVICE_PATTERN = new Regex(".+_cheets|cheets_.+");
+        private static readonly Regex ARC_DEVICE_PATTERN = new Regex(".+_cheets|cheets_.+");
 
-	    public static bool IsChromeOS(Context context)
-	    {
-	        return
-	            context.PackageManager.HasSystemFeature(
-	                "org.chromium.arc.device_management") // https://stackoverflow.com/a/39843396/292233
-	            || (Build.Device != null && ARC_DEVICE_PATTERN.IsMatch(Build.Device))
+        public static bool IsChromeOS(Context context)
+        {
+            return
+                context.PackageManager.HasSystemFeature(
+                    "org.chromium.arc.device_management") // https://stackoverflow.com/a/39843396/292233
+                || (Build.Device != null && ARC_DEVICE_PATTERN.IsMatch(Build.Device))
                 ;
-	    }
+        }
 
-        public static void GotoUrl(Context context, String url) {
-			if ( !string.IsNullOrEmpty(url) ) {
+        public static void GotoUrl(Context context, String url)
+        {
+            if (!string.IsNullOrEmpty(url))
+            {
 
-				if (url.StartsWith("androidapp://"))
-				{
-					string packageName = url.Substring("androidapp://".Length);
-					Intent startKp2aIntent = context.PackageManager.GetLaunchIntentForPackage(packageName);
-					if (startKp2aIntent != null)
-					{
-						startKp2aIntent.AddCategory(Intent.CategoryLauncher);
-						startKp2aIntent.AddFlags(ActivityFlags.NewTask);
-						context.StartActivity(startKp2aIntent);
-					}
-				}
-				else
-				{
-					Uri uri = Uri.Parse(url);
-					context.StartActivity(new Intent(
-						url.StartsWith("tel:") ? Intent.ActionDial : Intent.ActionView, 
-						uri));
-				}
-			}
-		}
-		
-		public static void GotoUrl(Context context, int resId)  {
-			GotoUrl(context, context.GetString(resId));
-		}
+                if (url.StartsWith("androidapp://"))
+                {
+                    string packageName = url.Substring("androidapp://".Length);
+                    Intent startKp2aIntent = context.PackageManager.GetLaunchIntentForPackage(packageName);
+                    if (startKp2aIntent != null)
+                    {
+                        startKp2aIntent.AddCategory(Intent.CategoryLauncher);
+                        startKp2aIntent.AddFlags(ActivityFlags.NewTask);
+                        context.StartActivity(startKp2aIntent);
+                    }
+                }
+                else
+                {
+                    Uri uri = Uri.Parse(url);
+                    context.StartActivity(new Intent(
+                        url.StartsWith("tel:") ? Intent.ActionDial : Intent.ActionView,
+                        uri));
+                }
+            }
+        }
 
-		public static void GotoMarket(Context context)
-		{
-			GotoUrl(context, context.GetString(Resource.String.MarketURL)+context.PackageName);
-		}
+        public static void GotoUrl(Context context, int resId)
+        {
+            GotoUrl(context, context.GetString(resId));
+        }
 
-		public static bool GotoDonateUrl(Context context)
-		{
-			string donateUrl = context.GetString(Resource.String.donate_url, 
-			                         new Java.Lang.Object[]{context.Resources.Configuration.Locale.Language,
-															context.PackageName
-			});
-			try
-			{
-				GotoUrl(context, donateUrl);
-				return true;
-			}
-			catch (ActivityNotFoundException)
-			{
-				Toast.MakeText(context, Resource.String.error_failed_to_launch_link, ToastLength.Long).Show();
-				return false;
-			}
-			
-		}
-		
-		public static String GetEditText(Activity act, int resId) {
-			TextView te =  (TextView) act.FindViewById(resId);
-			System.Diagnostics.Debug.Assert(te != null);
-			
-			if (te != null) {
-				return te.Text;
-			} else {
-				return "";
-			}
-		}
-		
-		public static void SetEditText(Activity act, int resId, String str) {
-			TextView te =  (TextView) act.FindViewById(resId);
-			System.Diagnostics.Debug.Assert(te != null);
-			
-			if (te != null) {
-				te.Text = str;
-			}
-		}
+        public static void GotoMarket(Context context)
+        {
+            GotoUrl(context, context.GetString(Resource.String.MarketURL) + context.PackageName);
+        }
 
-		/**
-	 * Indicates whether the specified action can be used as an intent. This
-	 * method queries the package manager for installed packages that can
-	 * respond to an intent with the specified action. If no suitable package is
-	 * found, this method returns false.
-	 *
-	 * @param context The application's environment.
-	 * @param action The Intent action to check for availability.
-	 *
-	 * @return True if an Intent with the specified action can be sent and
-	 *         responded to, false otherwise.
-	 */
-				static bool IsIntentAvailable(Context context, String action, String type, List<String> categories )
-		{
-			PackageManager packageManager = context.PackageManager;
-			Intent intent = new Intent(action);
-			if (type != null)
-				intent.SetType(type);
-			if (categories != null)
-				categories.ForEach(c => intent.AddCategory(c));
-			IList<ResolveInfo> list =
-				packageManager.QueryIntentActivities(intent,
-													 PackageInfoFlags.MatchDefaultOnly);
-			foreach (ResolveInfo i in list)
-				Kp2aLog.Log(i.ActivityInfo.ApplicationInfo.PackageName);
-			return list.Count > 0;
-		}
+        public static bool GotoDonateUrl(Context context)
+        {
+            string donateUrl = context.GetString(Resource.String.donate_url,
+                new Java.Lang.Object[]
+                {
+                    context.Resources.Configuration.Locale.Language,
+                    context.PackageName
+                });
+            try
+            {
+                GotoUrl(context, donateUrl);
+                return true;
+            }
+            catch (ActivityNotFoundException)
+            {
+                App.Kp2a.ShowMessage(context, Resource.String.error_failed_to_launch_link,  MessageSeverity.Error);
+                return false;
+            }
 
-		/// <summary>
-		/// Opens a browse dialog for selecting a file.
-		/// </summary>
-		/// <param name="activity">context activity</param>
-		/// <param name="requestCodeBrowse">requestCode for onActivityResult</param>
-		/// <param name="forSaving">if true, the file location is meant for saving</param>
-		/// <param name="tryGetPermanentAccess">if true, the caller prefers a location that can be used permanently
-		/// This means that ActionOpenDocument should be used instead of ActionGetContent (for not saving), as ActionGetContent
-		/// is more for one-time access, but therefore allows possibly more available sources.</param>
-		public static void ShowBrowseDialog(Activity activity, int requestCodeBrowse, bool forSaving, bool tryGetPermanentAccess)
-		{
-			//even though GetContent is not well supported (since Android 7, see https://commonsware.com/Android/previews/appendix-b-android-70) 
-			//we still offer it.
-			var loadAction = (tryGetPermanentAccess && IsKitKatOrLater) ? 
-							Intent.ActionOpenDocument : Intent.ActionGetContent;
-			if ((!forSaving) && (IsIntentAvailable(activity, loadAction, "*/*", new List<string> { Intent.CategoryOpenable})))
-			{
-				Intent i = new Intent(loadAction);
-				i.SetType("*/*");
-				i.AddCategory(Intent.CategoryOpenable);
+        }
 
-				activity.StartActivityForResult(i, requestCodeBrowse);
-			}
-			else
-			{
-				if ((forSaving) && (IsKitKatOrLater))
-				{
-					Intent i = new Intent(Intent.ActionCreateDocument);
-					i.SetType("*/*");
-					i.AddCategory(Intent.CategoryOpenable);
+        public static String GetEditText(Activity act, int resId)
+        {
+            TextView te = (TextView)act.FindViewById(resId);
+            System.Diagnostics.Debug.Assert(te != null);
 
-					activity.StartActivityForResult(i, requestCodeBrowse);
-				}
-				else
-				{
-					string defaultPath = Android.OS.Environment.ExternalStorageDirectory.AbsolutePath;
+            if (te != null)
+            {
+                return te.Text;
+            }
+            else
+            {
+                return "";
+            }
+        }
 
-					ShowInternalLocalFileChooser(activity, requestCodeBrowse, forSaving, defaultPath);	
-				}
-				
-			}
-		}
+        public static void SetEditText(Activity act, int resId, String str)
+        {
+            TextView te = (TextView)act.FindViewById(resId);
+            System.Diagnostics.Debug.Assert(te != null);
 
-		public static bool IsKitKatOrLater
-		{
-			get { return (int)Build.VERSION.SdkInt >= 19; }
-		}
+            if (te != null)
+            {
+                te.Text = str;
+            }
+        }
+
+        /**
+     * Indicates whether the specified action can be used as an intent. This
+     * method queries the package manager for installed packages that can
+     * respond to an intent with the specified action. If no suitable package is
+     * found, this method returns false.
+     *
+     * @param context The application's environment.
+     * @param action The Intent action to check for availability.
+     *
+     * @return True if an Intent with the specified action can be sent and
+     *         responded to, false otherwise.
+     */
+        static bool IsIntentAvailable(Context context, String action, String type, List<String> categories)
+        {
+            PackageManager packageManager = context.PackageManager;
+            Intent intent = new Intent(action);
+            if (type != null)
+                intent.SetType(type);
+            if (categories != null)
+                categories.ForEach(c => intent.AddCategory(c));
+            IList<ResolveInfo> list =
+                packageManager.QueryIntentActivities(intent,
+                    PackageInfoFlags.MatchDefaultOnly);
+            foreach (ResolveInfo i in list)
+                Kp2aLog.Log(i.ActivityInfo.ApplicationInfo.PackageName);
+            return list.Count > 0;
+        }
+
+        /// <summary>
+        /// Opens a browse dialog for selecting a file.
+        /// </summary>
+        /// <param name="activity">context activity</param>
+        /// <param name="requestCodeBrowse">requestCode for onActivityResult</param>
+        /// <param name="forSaving">if true, the file location is meant for saving</param>
+        /// <param name="tryGetPermanentAccess">if true, the caller prefers a location that can be used permanently
+        /// This means that ActionOpenDocument should be used instead of ActionGetContent (for not saving), as ActionGetContent
+        /// is more for one-time access, but therefore allows possibly more available sources.</param>
+        public static void ShowBrowseDialog(Activity activity, int requestCodeBrowse, bool forSaving,
+            bool tryGetPermanentAccess)
+        {
+            //even though GetContent is not well supported (since Android 7, see https://commonsware.com/Android/previews/appendix-b-android-70) 
+            //we still offer it.
+            var loadAction = (tryGetPermanentAccess && IsKitKatOrLater)
+                ? Intent.ActionOpenDocument
+                : Intent.ActionGetContent;
+            if ((!forSaving) &&
+                (IsIntentAvailable(activity, loadAction, "*/*", new List<string> { Intent.CategoryOpenable })))
+            {
+                Intent i = new Intent(loadAction);
+                i.SetType("*/*");
+                i.AddCategory(Intent.CategoryOpenable);
+
+                activity.StartActivityForResult(i, requestCodeBrowse);
+            }
+            else
+            {
+                if ((forSaving) && (IsKitKatOrLater))
+                {
+                    Intent i = new Intent(Intent.ActionCreateDocument);
+                    i.SetType("*/*");
+                    i.AddCategory(Intent.CategoryOpenable);
+
+                    activity.StartActivityForResult(i, requestCodeBrowse);
+                }
+                else
+                {
+                    string defaultPath = Android.OS.Environment.ExternalStorageDirectory.AbsolutePath;
+
+                    ShowInternalLocalFileChooser(activity, requestCodeBrowse, forSaving, defaultPath);
+                }
+
+            }
+        }
+
+        public static bool IsKitKatOrLater
+        {
+            get { return (int)Build.VERSION.SdkInt >= 19; }
+        }
 
 
         public static PendingIntentFlags AddMutabilityFlag(PendingIntentFlags flags, PendingIntentFlags mutability)
@@ -464,219 +486,227 @@ namespace keepass2android
             else return flags;
         }
 
-        private static void ShowInternalLocalFileChooser(Activity act, int requestCodeBrowse, bool forSaving, string defaultPath)
-		{
-			
+        private static void ShowInternalLocalFileChooser(Activity act, int requestCodeBrowse, bool forSaving,
+            string defaultPath)
+        {
+
 #if !EXCLUDE_FILECHOOSER
-			string fileProviderAuthority = act.PackageName+".android-filechooser.localfile";
+            string fileProviderAuthority = act.PackageName + ".android-filechooser.localfile";
 
-			Intent i = Keepass2android.Kp2afilechooser.Kp2aFileChooserBridge.GetLaunchFileChooserIntent(act,
-			                                                                                            fileProviderAuthority,
-			                                                                                            defaultPath);
-			if (forSaving)
-				i.PutExtra("group.pals.android.lib.ui.filechooser.FileChooserActivity.save_dialog", true);
+            Intent i = Keepass2android.Kp2afilechooser.Kp2aFileChooserBridge.GetLaunchFileChooserIntent(act,
+                fileProviderAuthority,
+                defaultPath);
+            if (forSaving)
+                i.PutExtra("group.pals.android.lib.ui.filechooser.FileChooserActivity.save_dialog", true);
 
-			act.StartActivityForResult(i, requestCodeBrowse);
+            act.StartActivityForResult(i, requestCodeBrowse);
 #else
-			Toast.MakeText(act, "File Chooser excluded!",ToastLength.Long).Show();
+			App.Kp2a.ShowMessage(act, "File Chooser excluded!", MessageSeverity.Error);
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Tries to extract the filename from the intent. Returns that filename or null if no success
-		/// (e.g. on content-URIs in Android KitKat+). 
-		/// Guarantees that the file exists.
-		/// </summary>
-		public static string IntentToFilename(Intent data, Context ctx)
-		{
-			string s = GetFilenameFromInternalFileChooser(data, ctx);
-			if (!String.IsNullOrEmpty(s))
-				return s;
+        /// <summary>
+        /// Tries to extract the filename from the intent. Returns that filename or null if no success
+        /// (e.g. on content-URIs in Android KitKat+). 
+        /// Guarantees that the file exists.
+        /// </summary>
+        public static string IntentToFilename(Intent data, Context ctx)
+        {
+            string s = GetFilenameFromInternalFileChooser(data, ctx);
+            if (!String.IsNullOrEmpty(s))
+                return s;
 
-			try
-			{
-				Uri uri = data.Data;
-				if ((uri != null) && (uri.Scheme == "content"))
-				{
-					String[] col = new String[] {MediaStore.MediaColumns.Data};
-					
-					ICursor c1 = ctx.ContentResolver.Query(uri, col, null, null, null);
-					c1.MoveToFirst();
+            try
+            {
+                Uri uri = data.Data;
+                if ((uri != null) && (uri.Scheme == "content"))
+                {
+                    String[] col = new String[] { MediaStore.MediaColumns.Data };
 
-					var possibleFilename = c1.GetString(0);
-					if (File.Exists(possibleFilename))
-						return possibleFilename;
-				}
-			}
-			catch (Exception e)
-			{
-				Kp2aLog.LogUnexpectedError(e);
-			}
+                    ICursor c1 = ctx.ContentResolver.Query(uri, col, null, null, null);
+                    c1.MoveToFirst();
 
-			String filename = data.Data.Path;
-			if ((String.IsNullOrEmpty(filename) || (!File.Exists(filename))))
-			 	filename = data.DataString;
-			if (File.Exists(filename))
-				return filename;
-			//found no valid file
-			return null;
-		}
+                    var possibleFilename = c1.GetString(0);
+                    if (File.Exists(possibleFilename))
+                        return possibleFilename;
+                }
+            }
+            catch (Exception e)
+            {
+                Kp2aLog.LogUnexpectedError(e);
+            }
 
-		public static string GetFilenameFromInternalFileChooser(Intent data, Context ctx)
-		{
+            String filename = data.Data.Path;
+            if ((String.IsNullOrEmpty(filename) || (!File.Exists(filename))))
+                filename = data.DataString;
+            if (File.Exists(filename))
+                return filename;
+            //found no valid file
+            return null;
+        }
+
+        public static string GetFilenameFromInternalFileChooser(Intent data, Context ctx)
+        {
 #if !EXCLUDE_FILECHOOSER
-			string EXTRA_RESULTS = "group.pals.android.lib.ui.filechooser.FileChooserActivity.results";
-			if (data.HasExtra(EXTRA_RESULTS))
-			{
-				IList uris = data.GetParcelableArrayListExtra(EXTRA_RESULTS);
-				Uri uri = (Uri) uris[0];
-				{
-					return Group.Pals.Android.Lib.UI.Filechooser.Providers.BaseFileProviderUtils.GetRealUri(ctx, uri).ToString();
-				}
-			}
+            string EXTRA_RESULTS = "group.pals.android.lib.ui.filechooser.FileChooserActivity.results";
+            if (data.HasExtra(EXTRA_RESULTS))
+            {
+                IList uris = data.GetParcelableArrayListExtra(EXTRA_RESULTS);
+                Uri uri = (Uri)uris[0];
+                {
+                    return Group.Pals.Android.Lib.UI.Filechooser.Providers.BaseFileProviderUtils.GetRealUri(ctx, uri)
+                        .ToString();
+                }
+            }
 
 #endif
-			return null;
-		}
+            return null;
+        }
 
 
-		public static bool HasActionBar(Activity activity)
-		{
-			//Actionbar is available since 11, but the layout has its own "pseudo actionbar" until 13
-			return ((int)Android.OS.Build.VERSION.SdkInt >= 14) && (activity.ActionBar != null);
-		}
+        public static bool HasActionBar(Activity activity)
+        {
+            //Actionbar is available since 11, but the layout has its own "pseudo actionbar" until 13
+            return ((int)Android.OS.Build.VERSION.SdkInt >= 14) && (activity.ActionBar != null);
+        }
 
-		public delegate bool FileSelectedHandler(string filename);
-
-		
-
-		public class DismissListener:  Java.Lang.Object, IDialogInterfaceOnDismissListener
-		{
-			private readonly Action _onDismiss;
-
-			public DismissListener(Action onDismiss)
-			{
-				_onDismiss = onDismiss;
-			}
-
-			public void OnDismiss(IDialogInterface dialog)
-			{
-				_onDismiss();
-			}
-		}
+        public delegate bool FileSelectedHandler(string filename);
 
 
-		class CancelListener: Java.Lang.Object, IDialogInterfaceOnCancelListener
-		{
-			private readonly Action _onCancel;
 
-			public CancelListener(Action onCancel)
-			{
-				_onCancel = onCancel;
-			}
+        public class DismissListener : Java.Lang.Object, IDialogInterfaceOnDismissListener
+        {
+            private readonly Action _onDismiss;
 
-			public void OnCancel(IDialogInterface dialog)
-			{
-				_onCancel();
-			}
-		}
+            public DismissListener(Action onDismiss)
+            {
+                _onDismiss = onDismiss;
+            }
 
-		public static void ShowFilenameDialog(Activity activity, Func<string, Dialog, bool> onOpen, Func<string, Dialog, bool> onCreate, Action onCancel, bool showBrowseButton, string defaultFilename, string detailsText, int requestCodeBrowse)
-		{
-			MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity);
-			builder.SetView(activity.LayoutInflater.Inflate(Resource.Layout.file_selection_filename, null));
-			
-			if (onCancel != null)
-				builder.SetOnCancelListener(new CancelListener(onCancel));
-			Dialog dialog = builder.Create();
-			dialog.Show();
-
-			Button openButton = (Button) dialog.FindViewById(Resource.Id.open);
-			Button createButton = (Button) dialog.FindViewById(Resource.Id.create);
-			
-			TextView enterFilenameDetails = (TextView) dialog.FindViewById(Resource.Id.label_open_by_filename_details);
-			openButton.Visibility = onOpen != null ? ViewStates.Visible : ViewStates.Gone;
-			createButton.Visibility = onCreate != null? ViewStates.Visible : ViewStates.Gone;
-			// Set the initial value of the filename
-			EditText editFilename = (EditText) dialog.FindViewById(Resource.Id.file_filename);
-			editFilename.Text = defaultFilename;
-			enterFilenameDetails.Text = detailsText;
-			enterFilenameDetails.Visibility = enterFilenameDetails.Text == "" ? ViewStates.Gone : ViewStates.Visible;
-
-			// Open button
-			if (onOpen != null)
-				openButton.Click += (sender, args) =>
-					{
-						String fileName = ((EditText) dialog.FindViewById(Resource.Id.file_filename)).Text;
-						if (onOpen(fileName, dialog))
-							dialog.Dismiss();
-					};
-
-			// Create button
-			if (onCreate != null)
-				createButton.Click += (sender, args) =>
-				{
-					String fileName = ((EditText)dialog.FindViewById(Resource.Id.file_filename)).Text;
-					if (onCreate(fileName, dialog))
-						dialog.Dismiss();
-				}; 
-			
-			Button cancelButton = (Button) dialog.FindViewById(Resource.Id.fnv_cancel);
-			cancelButton.Click += delegate
-				{
-					dialog.Dismiss();
-					if (onCancel != null)
-					onCancel();
-				};
-
-			ImageButton browseButton = (ImageButton) dialog.FindViewById(Resource.Id.browse_button);
-			if (!showBrowseButton)
-			{
-				browseButton.Visibility = ViewStates.Invisible;
-			}
-			browseButton.Click += (sender, evt) =>
-				{
-					string filename = ((EditText) dialog.FindViewById(Resource.Id.file_filename)).Text;
-
-					Util.ShowBrowseDialog(activity, requestCodeBrowse, onCreate != null, /*TODO should we prefer ActionOpenDocument here?*/ false);
-
-				};
-
-		}
-
-		public static void QueryCredentials(IOConnectionInfo ioc, Action<IOConnectionInfo> afterQueryCredentials, Activity activity)
-		{
-			//Build dialog to query credentials:
-			MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity);
-			builder.SetTitle(activity.GetString(Resource.String.credentials_dialog_title));
-			builder.SetPositiveButton(activity.GetString(Android.Resource.String.Ok), (dlgSender, dlgEvt) =>
-			{
-				Dialog dlg = (Dialog)dlgSender;
-				string username = ((EditText)dlg.FindViewById(Resource.Id.cred_username)).Text;
-				string password = ((EditText)dlg.FindViewById(Resource.Id.cred_password)).Text;
-				int credentialRememberMode = ((Spinner)dlg.FindViewById(Resource.Id.cred_remember_mode)).SelectedItemPosition;
-				ioc.UserName = username;
-				ioc.Password = password;
-				ioc.CredSaveMode = (IOCredSaveMode)credentialRememberMode;
-				afterQueryCredentials(ioc);
-			});
-			builder.SetView(activity.LayoutInflater.Inflate(Resource.Layout.url_credentials, null));
-			builder.SetNeutralButton(activity.GetString(Android.Resource.String.Cancel),
-									 (dlgSender, dlgEvt) => { });
-			Dialog dialog = builder.Create();
-			dialog.Show();
-			((EditText)dialog.FindViewById(Resource.Id.cred_username)).Text = ioc.UserName;
-			((EditText)dialog.FindViewById(Resource.Id.cred_password)).Text = ioc.Password;
-			((Spinner)dialog.FindViewById(Resource.Id.cred_remember_mode)).SetSelection((int)ioc.CredSaveMode);
-		}
+            public void OnDismiss(IDialogInterface dialog)
+            {
+                _onDismiss();
+            }
+        }
 
 
-		public static void FinishAndForward(Activity activity, Intent i)
-		{
-			i.SetFlags(ActivityFlags.ForwardResult);
-			activity.StartActivity(i);
-			activity.Finish();
-		}
+        class CancelListener : Java.Lang.Object, IDialogInterfaceOnCancelListener
+        {
+            private readonly Action _onCancel;
+
+            public CancelListener(Action onCancel)
+            {
+                _onCancel = onCancel;
+            }
+
+            public void OnCancel(IDialogInterface dialog)
+            {
+                _onCancel();
+            }
+        }
+
+        public static void ShowFilenameDialog(Activity activity, Func<string, Dialog, bool> onOpen,
+            Func<string, Dialog, bool> onCreate, Action onCancel, bool showBrowseButton, string defaultFilename,
+            string detailsText, int requestCodeBrowse)
+        {
+            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity);
+            builder.SetView(activity.LayoutInflater.Inflate(Resource.Layout.file_selection_filename, null));
+
+            if (onCancel != null)
+                builder.SetOnCancelListener(new CancelListener(onCancel));
+            Dialog dialog = builder.Create();
+            dialog.Show();
+
+            Button openButton = (Button)dialog.FindViewById(Resource.Id.open);
+            Button createButton = (Button)dialog.FindViewById(Resource.Id.create);
+
+            TextView enterFilenameDetails = (TextView)dialog.FindViewById(Resource.Id.label_open_by_filename_details);
+            openButton.Visibility = onOpen != null ? ViewStates.Visible : ViewStates.Gone;
+            createButton.Visibility = onCreate != null ? ViewStates.Visible : ViewStates.Gone;
+            // Set the initial value of the filename
+            EditText editFilename = (EditText)dialog.FindViewById(Resource.Id.file_filename);
+            editFilename.Text = defaultFilename;
+            enterFilenameDetails.Text = detailsText;
+            enterFilenameDetails.Visibility = enterFilenameDetails.Text == "" ? ViewStates.Gone : ViewStates.Visible;
+
+            // Open button
+            if (onOpen != null)
+                openButton.Click += (sender, args) =>
+                {
+                    String fileName = ((EditText)dialog.FindViewById(Resource.Id.file_filename)).Text;
+                    if (onOpen(fileName, dialog))
+                        dialog.Dismiss();
+                };
+
+            // Create button
+            if (onCreate != null)
+                createButton.Click += (sender, args) =>
+                {
+                    String fileName = ((EditText)dialog.FindViewById(Resource.Id.file_filename)).Text;
+                    if (onCreate(fileName, dialog))
+                        dialog.Dismiss();
+                };
+
+            Button cancelButton = (Button)dialog.FindViewById(Resource.Id.fnv_cancel);
+            cancelButton.Click += delegate
+            {
+                dialog.Dismiss();
+                if (onCancel != null)
+                    onCancel();
+            };
+
+            ImageButton browseButton = (ImageButton)dialog.FindViewById(Resource.Id.browse_button);
+            if (!showBrowseButton)
+            {
+                browseButton.Visibility = ViewStates.Invisible;
+            }
+
+            browseButton.Click += (sender, evt) =>
+            {
+                string filename = ((EditText)dialog.FindViewById(Resource.Id.file_filename)).Text;
+
+                Util.ShowBrowseDialog(activity, requestCodeBrowse,
+                    onCreate != null, /*TODO should we prefer ActionOpenDocument here?*/ false);
+
+            };
+
+        }
+
+        public static void QueryCredentials(IOConnectionInfo ioc, Action<IOConnectionInfo> afterQueryCredentials,
+            Activity activity)
+        {
+            //Build dialog to query credentials:
+            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity);
+            builder.SetTitle(activity.GetString(Resource.String.credentials_dialog_title));
+            builder.SetPositiveButton(activity.GetString(Android.Resource.String.Ok), (dlgSender, dlgEvt) =>
+            {
+                Dialog dlg = (Dialog)dlgSender;
+                string username = ((EditText)dlg.FindViewById(Resource.Id.cred_username)).Text;
+                string password = ((EditText)dlg.FindViewById(Resource.Id.cred_password)).Text;
+                int credentialRememberMode =
+                    ((Spinner)dlg.FindViewById(Resource.Id.cred_remember_mode)).SelectedItemPosition;
+                ioc.UserName = username;
+                ioc.Password = password;
+                ioc.CredSaveMode = (IOCredSaveMode)credentialRememberMode;
+                afterQueryCredentials(ioc);
+            });
+            builder.SetView(activity.LayoutInflater.Inflate(Resource.Layout.url_credentials, null));
+            builder.SetNeutralButton(activity.GetString(Android.Resource.String.Cancel),
+                (dlgSender, dlgEvt) => { });
+            Dialog dialog = builder.Create();
+            dialog.Show();
+            ((EditText)dialog.FindViewById(Resource.Id.cred_username)).Text = ioc.UserName;
+            ((EditText)dialog.FindViewById(Resource.Id.cred_password)).Text = ioc.Password;
+            ((Spinner)dialog.FindViewById(Resource.Id.cred_remember_mode)).SetSelection((int)ioc.CredSaveMode);
+        }
+
+
+        public static void FinishAndForward(Activity activity, Intent i)
+        {
+            i.SetFlags(ActivityFlags.ForwardResult);
+            activity.StartActivity(i);
+            activity.Finish();
+        }
 
         public static void PrepareDonateOptionMenu(IMenu menu, Context ctx)
         {
@@ -685,12 +715,12 @@ namespace keepass2android
             {
                 donateItem.SetVisible(
                     !PreferenceManager.GetDefaultSharedPreferences(ctx)
-                                     .GetBoolean(ctx.GetString(Resource.String.NoDonateOption_key), false)
-                    );
+                        .GetBoolean(ctx.GetString(Resource.String.NoDonateOption_key), false)
+                );
             }
         }
 
-		
+
         public static bool GetCloseDatabaseAfterFailedBiometricQuickUnlock(Context ctx)
         {
             return (PreferenceManager.GetDefaultSharedPreferences(ctx).GetBoolean(
@@ -699,102 +729,110 @@ namespace keepass2android
         }
 
 
-        
+
 
 
         public static void MoveBottomBarButtons(int btn1Id, int btn2Id, int bottomBarId, Activity context)
-		{
-			var btn1 = context.FindViewById<Button>(btn1Id);
-			var btn2 = context.FindViewById<Button>(btn2Id);
-			var rl = context.FindViewById<RelativeLayout>(bottomBarId);
-			rl.ViewTreeObserver.GlobalLayout += (sender, args) =>
-			{
-				if (btn1.Width + btn2.Width > rl.Width)
-				{
-					btn2.SetPadding(btn2.PaddingLeft, (int) Util.convertDpToPixel(40, context), btn2.PaddingRight, btn2.PaddingBottom);
-				}
-			};
-		}
-
-		public static MemoryStream StreamToMemoryStream(Stream stream)
-		{
-		
-			var memoryStream = stream as MemoryStream;
-			if (memoryStream == null)
-			{
-				// Read the stream into memory
-				int capacity = 4096; // Default initial capacity, if stream can't report it.
-				if (stream.CanSeek)
-				{
-					capacity = (int) stream.Length;
-				}
-				memoryStream = new MemoryStream(capacity);
-				stream.CopyTo(memoryStream);
-				stream.Close();
-				memoryStream.Seek(0, SeekOrigin.Begin);
-			}
-			return memoryStream;
-		
-		}
-
-	    public static Bitmap MakeLargeIcon(Bitmap unscaled, Context context)
-	    {
-	        int height = (int)(0.9 * context.Resources.GetDimension(Android.Resource.Dimension.NotificationLargeIconHeight));
-	        int width = (int)(0.9 * context.Resources.GetDimension(Android.Resource.Dimension.NotificationLargeIconWidth));
-	        return Bitmap.CreateScaledBitmap(unscaled, width, height, true);
+        {
+            var btn1 = context.FindViewById<Button>(btn1Id);
+            var btn2 = context.FindViewById<Button>(btn2Id);
+            var rl = context.FindViewById<RelativeLayout>(bottomBarId);
+            rl.ViewTreeObserver.GlobalLayout += (sender, args) =>
+            {
+                if (btn1.Width + btn2.Width > rl.Width)
+                {
+                    btn2.SetPadding(btn2.PaddingLeft, (int)Util.convertDpToPixel(40, context), btn2.PaddingRight,
+                        btn2.PaddingBottom);
+                }
+            };
         }
 
-	    public static string GetProtocolId(IOConnectionInfo ioc)
-	    {
-	        string displayPath = App.Kp2a.GetFileStorage(ioc).GetDisplayName(ioc);
-	        int protocolSeparatorPos = displayPath.IndexOf("://", StringComparison.Ordinal);
-	        string protocolId = protocolSeparatorPos < 0 ?
-	            "file" : displayPath.Substring(0, protocolSeparatorPos);
-	        return protocolId;
-	    }
+        public static MemoryStream StreamToMemoryStream(Stream stream)
+        {
 
-	    public static void MakeSecureDisplay(Activity context)
-	    {
-	        if (SecureDisplayConfigured(context) && !PreferenceManager.GetDefaultSharedPreferences(context).GetBoolean("no_secure_display_check", false))
+            var memoryStream = stream as MemoryStream;
+            if (memoryStream == null)
+            {
+                // Read the stream into memory
+                int capacity = 4096; // Default initial capacity, if stream can't report it.
+                if (stream.CanSeek)
+                {
+                    capacity = (int)stream.Length;
+                }
+
+                memoryStream = new MemoryStream(capacity);
+                stream.CopyTo(memoryStream);
+                stream.Close();
+                memoryStream.Seek(0, SeekOrigin.Begin);
+            }
+
+            return memoryStream;
+
+        }
+
+        public static Bitmap MakeLargeIcon(Bitmap unscaled, Context context)
+        {
+            int height =
+                (int)(0.9 * context.Resources.GetDimension(Android.Resource.Dimension.NotificationLargeIconHeight));
+            int width = (int)(0.9 *
+                              context.Resources.GetDimension(Android.Resource.Dimension.NotificationLargeIconWidth));
+            return Bitmap.CreateScaledBitmap(unscaled, width, height, true);
+        }
+
+        public static string GetProtocolId(IOConnectionInfo ioc)
+        {
+            string displayPath = App.Kp2a.GetFileStorage(ioc).GetDisplayName(ioc);
+            int protocolSeparatorPos = displayPath.IndexOf("://", StringComparison.Ordinal);
+            string protocolId = protocolSeparatorPos < 0 ? "file" : displayPath.Substring(0, protocolSeparatorPos);
+            return protocolId;
+        }
+
+        public static void MakeSecureDisplay(Activity context)
+        {
+            if (SecureDisplayConfigured(context) && !PreferenceManager.GetDefaultSharedPreferences(context)
+                    .GetBoolean("no_secure_display_check", false))
             {
                 var hasUnsecureDisplay = HasUnsecureDisplay(context);
-	            if (hasUnsecureDisplay)
-	            {
-	                var intent = new Intent(context, typeof(NoSecureDisplayActivity));
-	                intent.AddFlags(ActivityFlags.SingleTop | ActivityFlags.ClearTop);
-	                context.StartActivityForResult(intent,9999);
-	            }
-	            context.Window.SetFlags(WindowManagerFlags.Secure, WindowManagerFlags.Secure);
-	        }
+                if (hasUnsecureDisplay)
+                {
+                    var intent = new Intent(context, typeof(NoSecureDisplayActivity));
+                    intent.AddFlags(ActivityFlags.SingleTop | ActivityFlags.ClearTop);
+                    context.StartActivityForResult(intent, 9999);
+                }
+
+                context.Window.SetFlags(WindowManagerFlags.Secure, WindowManagerFlags.Secure);
+            }
         }
 
-	    public static bool SecureDisplayConfigured(Activity context)
-	    {
-	        return PreferenceManager.GetDefaultSharedPreferences(context).GetBoolean(
-	            context.GetString(Resource.String.ViewDatabaseSecure_key), true);
-	    }
+        public static bool SecureDisplayConfigured(Activity context)
+        {
+            return PreferenceManager.GetDefaultSharedPreferences(context).GetBoolean(
+                context.GetString(Resource.String.ViewDatabaseSecure_key), true);
+        }
 
-	    public static bool HasUnsecureDisplay(Activity context)
-	    {
-	        bool hasUnsecureDisplay = false;
-	        if ((int) Build.VERSION.SdkInt >= 17)
-	        {
-	            foreach (var display in ((DisplayManager) context.GetSystemService(Context.DisplayService)).GetDisplays())
-	            {
-	                if ((display.Flags & DisplayFlags.Secure) == 0)
-	                {
-	                    hasUnsecureDisplay = true;
-	                }
-	            }
-	        }
-	        return hasUnsecureDisplay;
-	    }
+        public static bool HasUnsecureDisplay(Activity context)
+        {
+            bool hasUnsecureDisplay = false;
+            if ((int)Build.VERSION.SdkInt >= 17)
+            {
+                foreach (var display in ((DisplayManager)context.GetSystemService(Context.DisplayService))
+                         .GetDisplays())
+                {
+                    if ((display.Flags & DisplayFlags.Secure) == 0)
+                    {
+                        hasUnsecureDisplay = true;
+                    }
+                }
+            }
+
+            return hasUnsecureDisplay;
+        }
 
         public static void SetNoPersonalizedLearning(EditText editText)
         {
             if (editText == null)
                 return;
-            if ((int) Build.VERSION.SdkInt >= 26)
+            if ((int)Build.VERSION.SdkInt >= 26)
                 editText.ImeOptions = (ImeAction)EditorInfoCompat.ImeFlagNoPersonalizedLearning;
             ;
 
@@ -804,7 +842,7 @@ namespace keepass2android
         {
             if (view is ViewGroup vg)
             {
-                for (int i=0;i<vg.ChildCount;i++)
+                for (int i = 0; i < vg.ChildCount; i++)
                 {
                     SetNoPersonalizedLearning(vg.GetChildAt(i));
                 }
@@ -826,7 +864,9 @@ namespace keepass2android
             }
 
             entry.Strings.Set(prefix + c, new ProtectedString(false, url));
-		}
+        }
+
+
     }
 }
 

--- a/src/keepass2android-app/app/AppTask.cs
+++ b/src/keepass2android-app/app/AppTask.cs
@@ -646,8 +646,8 @@ namespace keepass2android
                     string totp = prov.GenerateByByte(totpData.TotpSecret);
                     CopyToClipboardService.CopyValueToClipboardWithTimeout(activity, totp, true);
 
-                    Toast.MakeText(activity, activity.GetString(Resource.String.TotpCopiedToClipboard),
-                        ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(activity, activity.GetString(Resource.String.TotpCopiedToClipboard),
+                         MessageSeverity.Info);
                 }
 
                 
@@ -990,9 +990,9 @@ namespace keepass2android
 
 				if (ToastEnable) {
 					String toastMessage = groupBaseActivity.GetString (Resource.String.NavigationToGroupCompleted_message, new Java.Lang.Object[] { FullGroupName});
-					
-					Toast.MakeText (groupBaseActivity, toastMessage, ToastLength.Long).Show ();
-				}
+
+                    App.Kp2a.ShowMessage(groupBaseActivity, toastMessage, MessageSeverity.Info);
+                }
 				
 				groupBaseActivity.StartTask (TaskToBeLaunchedAfterNavigation);
 				return;

--- a/src/keepass2android-app/app/OtpAuxCacheSupervisor.cs
+++ b/src/keepass2android-app/app/OtpAuxCacheSupervisor.cs
@@ -28,7 +28,7 @@ namespace keepass2android
 		public void UpdatedCachedFileOnLoad(IOConnectionInfo ioc)
 		{
 			_app.ShowToast(LocaleManager.LocalizedAppContext.GetString(Resource.String.UpdatedCachedFileOnLoad,
-			                                             new Java.Lang.Object[] { LocaleManager.LocalizedAppContext.GetString(Resource.String.otp_aux_file) }));
+			                                             new Java.Lang.Object[] { LocaleManager.LocalizedAppContext.GetString(Resource.String.otp_aux_file) }), MessageSeverity.Info);
 		}
 
 		public void UpdatedRemoteFileOnLoad(IOConnectionInfo ioc)
@@ -49,12 +49,12 @@ namespace keepass2android
 
 		public void ResolvedCacheConflictByUsingRemote(IOConnectionInfo ioc)
 		{
-			_app.ShowToast(LocaleManager.LocalizedAppContext.GetString(Resource.String.ResolvedCacheConflictByUsingRemoteOtpAux));
+			_app.ShowToast(LocaleManager.LocalizedAppContext.GetString(Resource.String.ResolvedCacheConflictByUsingRemoteOtpAux), MessageSeverity.Info);
 		}
 
 		public void ResolvedCacheConflictByUsingLocal(IOConnectionInfo ioc)
 		{
-			_app.ShowToast(LocaleManager.LocalizedAppContext.GetString(Resource.String.ResolvedCacheConflictByUsingLocalOtpAux));
+			_app.ShowToast(LocaleManager.LocalizedAppContext.GetString(Resource.String.ResolvedCacheConflictByUsingLocalOtpAux), MessageSeverity.Info);
 		}
 	}
 }

--- a/src/keepass2android-app/fileselect/FileSelectActivity.cs
+++ b/src/keepass2android-app/fileselect/FileSelectActivity.cs
@@ -35,6 +35,7 @@ using Console = System.Console;
 using Environment = Android.OS.Environment;
 using Google.Android.Material.AppBar;
 using Android.Util;
+using keepass2android.Utils;
 
 namespace keepass2android
 {
@@ -75,7 +76,7 @@ namespace keepass2android
 
         public const string NoForwardToPasswordActivity = "NoForwardToPasswordActivity";
 
-		protected override void OnCreate(Bundle savedInstanceState)
+        protected override void OnCreate(Bundle savedInstanceState)
 		{
 			_design.ApplyTheme(); 
 			base.OnCreate(savedInstanceState);
@@ -327,7 +328,7 @@ namespace keepass2android
             }
             catch (NoFileStorageFoundException)
             {
-                Toast.MakeText(this, "Don't know how to handle " + newConnectionInfo.Path, ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, "Don't know how to handle " + newConnectionInfo.Path,  MessageSeverity.Error);
                 return;
             }
 
@@ -376,7 +377,7 @@ namespace keepass2android
 					Finish();
 				} catch (Java.IO.FileNotFoundException)
 				{
-					Toast.MakeText(this, Resource.String.FileNotFound, ToastLength.Long).Show();
+					App.Kp2a.ShowMessage(this, Resource.String.FileNotFound,  MessageSeverity.Error);
 				} 
 			}
 		}
@@ -432,8 +433,9 @@ namespace keepass2android
 			base.OnResume();
 			App.Kp2a.OfflineMode = false; //no matter what the preferences are, file selection or db creation is performed offline. PasswordActivity might set this to true.
 			Kp2aLog.Log("FileSelect.OnResume");
+            App.Kp2a.MessagePresenter = new ChainedSnackbarPresenter(FindViewById(Resource.Id.main_content));
 
-			_design.ReapplyTheme();
+            _design.ReapplyTheme();
 
 			// Check to see if we need to change modes
 			if (ShowRecentFiles() != _recentMode)
@@ -485,7 +487,7 @@ namespace keepass2android
             catch (Exception e)
             {
                 Kp2aLog.LogUnexpectedError(e);
-                Toast.MakeText(this, "Error: " + e.Message, ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, "Error: " + e.Message,  MessageSeverity.Error);
                 Finish();
             }
 
@@ -503,7 +505,8 @@ namespace keepass2android
 		protected override void OnPause()
 		{
 			base.OnPause();
-			Kp2aLog.Log("FileSelect.OnPause");
+            App.Kp2a.MessagePresenter = new NonePresenter();
+            Kp2aLog.Log("FileSelect.OnPause");
 		}
 
 		protected override void OnDestroy()

--- a/src/keepass2android-app/search/SearchResults.cs
+++ b/src/keepass2android-app/search/SearchResults.cs
@@ -94,7 +94,7 @@ namespace keepass2android.search
 			    catch (Exception e)
 			    {
 			        Kp2aLog.Log("Failed to transform " + intent.Data.LastPathSegment + " to an ElementAndDatabaseId object. ");
-			        Toast.MakeText(this, "Bad path passed. Please provide database and element ID.", ToastLength.Long).Show();
+			        App.Kp2a.ShowMessage(this, "Bad path passed. Please provide database and element ID.",  MessageSeverity.Error);
                     Finish();
 			        return;
 			    }
@@ -121,7 +121,7 @@ namespace keepass2android.search
                 edit.PutLong(GetString(Resource.String.UsageCount_key), 1000);
                 edit.PutBoolean("DismissedDonateReminder", true);
                 edit.Commit();
-                Toast.MakeText(this, "Please go to Settings - App - Display to disable donation requests.", ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, "Please go to Settings - App - Display to disable donation requests.",  MessageSeverity.Error);
             }
         
 
@@ -142,7 +142,7 @@ namespace keepass2android.search
                 }
             } catch (Exception e) {
 				Kp2aLog.LogUnexpectedError(e);
-				Toast.MakeText(this,e.Message, ToastLength.Long).Show();
+				App.Kp2a.ShowMessage(this,e.Message,  MessageSeverity.Error);
 				Finish();
 				return;
 			}

--- a/src/keepass2android-app/search/SearchTotpResults.cs
+++ b/src/keepass2android-app/search/SearchTotpResults.cs
@@ -96,7 +96,7 @@ namespace keepass2android.search
             catch (Exception e)
             {
                 Kp2aLog.LogUnexpectedError(e);
-                Toast.MakeText(this, e.Message, ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, e.Message,  MessageSeverity.Error);
                 Finish();
                 return;
             }

--- a/src/keepass2android-app/services/AutofillBase/ChooseForAutofillActivityBase.cs
+++ b/src/keepass2android-app/services/AutofillBase/ChooseForAutofillActivityBase.cs
@@ -52,7 +52,7 @@ namespace keepass2android.services.AutofillBase
             if (requestedUrl == null && requestedUuid == null)
             {
                 Kp2aLog.Log("ChooseForAutofillActivityBase: no requestedUrl and no requestedUuid");
-                Toast.MakeText(this, "Cannot execute query for null.", ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, "Cannot execute query for null.",  MessageSeverity.Error);
                 RestartApp();
                 return;
             }
@@ -255,7 +255,7 @@ namespace keepass2android.services.AutofillBase
         {
             if (dataset == null)
             {
-                Toast.MakeText(this, "Failed to build an autofill dataset.", ToastLength.Long).Show();
+                App.Kp2a.ShowMessage(this, "Failed to build an autofill dataset.",  MessageSeverity.Error);
                 return;
             }
             ReplyIntent.PutExtra(AutofillManager.ExtraAuthenticationResult, dataset);

--- a/src/keepass2android-app/services/CopyToClipboardService.cs
+++ b/src/keepass2android-app/services/CopyToClipboardService.cs
@@ -710,9 +710,9 @@ namespace keepass2android
                 string message = _service.GetString(Resource.String.ClearClipboard) + " "
                                  + _service.GetString(Resource.String.ClearClipboardWarning);
                 Android.Util.Log.Debug("KP2A", message);
-                Toast.MakeText(_service,
+                App.Kp2a.ShowMessage(_service,
                     message,
-                    ToastLength.Long).Show();
+                     MessageSeverity.Error);
             }
         }
 
@@ -781,7 +781,7 @@ namespace keepass2android
                 InputMethodManager imeManager = (InputMethodManager)ApplicationContext.GetSystemService(InputMethodService);
                 if (imeManager == null)
                 {
-                    Toast.MakeText(this, Resource.String.not_possible_im_picker, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(this, Resource.String.not_possible_im_picker,  MessageSeverity.Error);
                     return;
                 }
                 try
@@ -799,7 +799,7 @@ namespace keepass2android
                     }
                     catch (Exception)
                     {
-                        Toast.MakeText(this, Resource.String.not_possible_im_picker, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(this, Resource.String.not_possible_im_picker,  MessageSeverity.Error);
                     }
                     return;
                 }
@@ -813,7 +813,7 @@ namespace keepass2android
                 if (!IsKp2aInputMethodEnabled)
                 {
                     //must be enabled in settings first
-                    Toast.MakeText(this, Resource.String.please_activate_keyboard, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(this, Resource.String.please_activate_keyboard,  MessageSeverity.Info);
                     Intent settingsIntent = new Intent(Android.Provider.Settings.ActionInputMethodSettings);
                     try
                     {
@@ -824,7 +824,7 @@ namespace keepass2android
                     {
                         //seems like on Huawei devices this call can fail. 
                         Kp2aLog.LogUnexpectedError(e);
-                        Toast.MakeText(this, "Failed to switch keyboard.", ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(this, "Failed to switch keyboard.",  MessageSeverity.Error);
 
                     }
                 }
@@ -847,7 +847,7 @@ namespace keepass2android
                         {
                             //seems like on Huawei devices this call can fail. 
                             Kp2aLog.LogUnexpectedError(e);
-                            Toast.MakeText(this, "Failed to switch keyboard.", ToastLength.Long).Show();
+                            App.Kp2a.ShowMessage(this, "Failed to switch keyboard.",  MessageSeverity.Error);
 
                         }
                         

--- a/src/keepass2android-app/settings/AppSettingsActivity.cs
+++ b/src/keepass2android-app/settings/AppSettingsActivity.cs
@@ -123,7 +123,7 @@ namespace keepass2android
                             {
                                 db.KpDatabase.DefaultUserName = previousUsername;
                                 db.KpDatabase.DefaultUserNameChanged = previousUsernameChanged;
-                                Toast.MakeText(activity, message, ToastLength.Long).Show();
+                                App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                             }
                         }));
                         ProgressTask pt = new ProgressTask(App.Kp2a, Activity, save);
@@ -189,7 +189,7 @@ namespace keepass2android
                             {
                                 db.KpDatabase.Name = previousName;
                                 db.KpDatabase.NameChanged = previousNameChanged;
-                                Toast.MakeText(activity, message, ToastLength.Long).Show();
+                                App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                             }
                             else
                             {
@@ -261,7 +261,7 @@ namespace keepass2android
                     {
                         return () =>
                         {
-                            Toast.MakeText(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message, ToastLength.Long).Show();
+                            App.Kp2a.ShowMessage(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message,  MessageSeverity.Error);
                         };
                     }
 
@@ -357,7 +357,7 @@ namespace keepass2android
                     {
                         return () =>
                         {
-                            Toast.MakeText(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message, ToastLength.Long).Show();
+                            App.Kp2a.ShowMessage(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message,  MessageSeverity.Error);
                         };
                     }
 
@@ -415,7 +415,7 @@ namespace keepass2android
                     if (!success)
                     {
                         db.KpDatabase.DataCipherUuid = previousCipher;
-                        Toast.MakeText(activity, message, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                         return;
                     }
                     preferenceChangeEventArgs.Preference.Summary =
@@ -628,7 +628,7 @@ namespace keepass2android
                             catch (Exception ex)
                             {
                                 Kp2aLog.LogUnexpectedError(ex);
-                                Toast.MakeText(LocaleManager.LocalizedAppContext, ex.Message, ToastLength.Long).Show();
+                                App.Kp2a.ShowMessage(LocaleManager.LocalizedAppContext, ex.Message,  MessageSeverity.Error);
                             }
                         }
                     );
@@ -1076,7 +1076,7 @@ namespace keepass2android
                     if (!success)
                     {
                         db.KpDatabase.KdfParameters = previousKdfParams;
-                        Toast.MakeText(activity, message, ToastLength.Long).Show();
+                        App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                         return;
                     }
                     UpdateKdfScreen();

--- a/src/keepass2android-app/settings/ExportKeyfileActivity.cs
+++ b/src/keepass2android-app/settings/ExportKeyfileActivity.cs
@@ -74,10 +74,10 @@ namespace keepass2android
                     (success, message, activity) =>
                     {
                         if (!success)
-                            Toast.MakeText(activity, message, ToastLength.Long).Show();
+                            App.Kp2a.ShowMessage(activity, message,  MessageSeverity.Error);
                         else
-                            Toast.MakeText(activity, _activity.GetString(Resource.String.export_keyfile_successful),
-                                ToastLength.Long).Show();
+                            App.Kp2a.ShowMessage(activity, _activity.GetString(Resource.String.export_keyfile_successful),
+                                 MessageSeverity.Info);
                         activity.Finish();
                     }
                 ), ioc);

--- a/src/keepass2android-app/settings/RoundsPreference.cs
+++ b/src/keepass2android-app/settings/RoundsPreference.cs
@@ -94,7 +94,7 @@ namespace keepass2android.settings
                 String strRounds = inputEditText.Text;
                 if (!(ulong.TryParse(strRounds, out paramValue)))
                 {
-                    Toast.MakeText(Context, Resource.String.error_param_not_number, ToastLength.Long).Show();
+                    App.Kp2a.ShowMessage(Context, Resource.String.error_param_not_number,  MessageSeverity.Error);
                     return;
                 }
 


### PR DESCRIPTION
This PR adds changes such that toast messages are only used if no activity is present which can show snackbars.

This solves a variety of issues:
 * closes https://github.com/PhilippC/keepass2android/issues/638 (annoying toast)
 * closes https://github.com/PhilippC/keepass2android/issues/1937 (toast on top of keyboard)
 * closes https://github.com/PhilippC/keepass2android/issues/2026 (toast on top of keyboard)
 * closes https://github.com/PhilippC/keepass2android/issues/2069 (too many messages and too long display time. snackbars can be swiped away)
 * closes https://github.com/PhilippC/keepass2android/issues/2187  (toast on top of keyboard)
 * closes https://github.com/PhilippC/keepass2android/issues/2333  (toast on top of keyboard)
 * closes https://github.com/PhilippC/keepass2android/issues/2401 (toast on top of keyboard)
 * closes https://github.com/PhilippC/keepass2android/issues/2587 (long messages not displayed completely, might disappear before read. Snackbars: tap on them to avoid that they disappear)