### PR TITLE
Improve error reporting and fix crash

### DIFF
--- a/src/Kp2aBusinessLogic/Io/BuiltInFileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/BuiltInFileStorage.cs
@@ -13,7 +13,7 @@ using Android.Content.PM;
 using Android.OS;
 using Android.Preferences;
 using Java.IO;
-
+using KeePass.Util;
 using KeePassLib.Serialization;
 using KeePassLib.Utility;
 using File = System.IO.File;
@@ -121,7 +121,7 @@ namespace keepass2android.Io
 			var response = ex.Response as HttpWebResponse;
 			if ((response != null) && (response.StatusCode == HttpStatusCode.NotFound))
 			{
-				throw new FileNotFoundException(ex.Message, ioc.Path, ex);
+				throw new FileNotFoundException(ExceptionUtil.GetErrorMessage(ex), ioc.Path, ex);
 			}
 			if (ex.Status == WebExceptionStatus.TrustFailure)
 			{

--- a/src/Kp2aBusinessLogic/Io/JavaFileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/JavaFileStorage.cs
@@ -13,6 +13,7 @@ using Keepass2android.Javafilestorage;
 #endif
 using Exception = System.Exception;
 using FileNotFoundException = Java.IO.FileNotFoundException;
+using KeePass.Util;
 
 namespace keepass2android.Io
 {
@@ -42,7 +43,7 @@ namespace keepass2android.Io
 			}
 			catch (FileNotFoundException e)
 			{
-				throw new System.IO.FileNotFoundException(e.Message, e);
+				throw new System.IO.FileNotFoundException(ExceptionUtil.GetErrorMessage(e), e);
 			}
 			catch (Java.Lang.Exception e)
 			{
@@ -195,7 +196,7 @@ namespace keepass2android.Io
 			}
 			catch (FileNotFoundException e)
 			{
-				throw new System.IO.FileNotFoundException(e.Message, e);
+				throw new System.IO.FileNotFoundException(ExceptionUtil.GetErrorMessage(e), e);
 			}
 			catch (Java.Lang.Exception e)
 			{
@@ -214,7 +215,7 @@ namespace keepass2android.Io
 			}
 			catch (FileNotFoundException e)
 			{
-				throw new System.IO.FileNotFoundException(e.Message, e);
+				throw new System.IO.FileNotFoundException(ExceptionUtil.GetErrorMessage(e), e);
 			}
 			catch (Java.Lang.Exception e)
 			{
@@ -244,7 +245,7 @@ namespace keepass2android.Io
 			}
 			catch (FileNotFoundException e)
 			{
-				throw new System.IO.FileNotFoundException(e.Message, e);
+				throw new System.IO.FileNotFoundException(ExceptionUtil.GetErrorMessage(e), e);
 			}
 			catch (Java.Lang.Exception e)
 			{

--- a/src/Kp2aBusinessLogic/Io/NetFtpFileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/NetFtpFileStorage.cs
@@ -8,6 +8,7 @@ using Android.Content;
 using Android.OS;
 using FluentFTP;
 using FluentFTP.Exceptions;
+using KeePass.Util;
 using KeePassLib;
 using KeePassLib.Serialization;
 using KeePassLib.Utility;
@@ -127,7 +128,7 @@ namespace keepass2android.Io
 				var ftpEx = (FtpCommandException) exception;
 
 				if (ftpEx.CompletionCode == "550")
-					throw new FileNotFoundException(exception.Message, exception);
+					throw new FileNotFoundException(ExceptionUtil.GetErrorMessage(exception), exception);
 			}
 
 			return exception;

--- a/src/Kp2aBusinessLogic/Io/OneDrive2FileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/OneDrive2FileStorage.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text;
 using Android.Content;
 using Android.Util;
+using KeePass.Util;
 using keepass2android.Io.ItemLocation;
 using KeePassLib.Serialization;
 using KeePassLib.Utility;
@@ -522,10 +523,10 @@ namespace keepass2android.Io
         {
 
             if (e.IsMatch(GraphErrorCode.ItemNotFound.ToString()))
-                return new FileNotFoundException(e.Message);
+                return new FileNotFoundException(ExceptionUtil.GetErrorMessage(e));
             if (e.Message.Contains("\n\n404 : ")
             ) //hacky solution to check for not found. errorCode was null in my tests so I had to find a workaround.
-                return new FileNotFoundException(e.Message);
+                return new FileNotFoundException(ExceptionUtil.GetErrorMessage(e));
             return e;
         }
 

--- a/src/Kp2aBusinessLogic/Io/OneDriveFileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/OneDriveFileStorage.cs
@@ -16,20 +16,32 @@ namespace keepass2android.Io
     /// </summary>
 	public class OneDriveFileStorage: IFileStorage
 	{
-		
-		public IEnumerable<string> SupportedProtocols
+        public OneDriveFileStorage(IKp2aApp app)
+        {
+            _app = app;
+        }
+
+        private readonly IKp2aApp _app;
+
+        public IEnumerable<string> SupportedProtocols
 		{
 			get
 			{
 				yield return "skydrive";
 				yield return "onedrive";
-			}
+            }
 		}
 
-        private Exception GetDeprecatedMessage()
+        string GetDeprecatedMessage()
+        {
+            return
+                "You have opened your file through a deprecated Microsoft API. Please select Change database, Open Database and then select OneDrive again.";
+        }
+
+        private Exception GetDeprecatedException()
         {
             return new Exception(
-                "You have opened your file through a deprecated Microsoft API. Please select Change database, Open Database and then select One Drive again.");
+                GetDeprecatedMessage());
         }
 
 	    public bool UserShouldBackup
@@ -39,133 +51,132 @@ namespace keepass2android.Io
 
         public void Delete(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public bool CheckForFileChangeFast(IOConnectionInfo ioc, string previousFileVersion)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public string GetCurrentFileVersionFast(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public Stream OpenFileForRead(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public IWriteTransaction OpenWriteTransaction(IOConnectionInfo ioc, bool useFileTransaction)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public string GetFilenameWithoutPathAndExt(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public string GetFileExtension(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public bool RequiresCredentials(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            return false;
         }
 
         public void CreateDirectory(IOConnectionInfo ioc, string newDirName)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public IEnumerable<FileDescription> ListContents(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public FileDescription GetFileDescription(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public bool RequiresSetup(IOConnectionInfo ioConnection)
         {
-            throw GetDeprecatedMessage();
+            return false;
         }
 
         public string IocToPath(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public void StartSelectFile(IFileStorageSetupInitiatorActivity activity, bool isForSave, int requestCode, string protocolId)
         {
-            throw GetDeprecatedMessage();
+            
         }
 
         public void PrepareFileUsage(IFileStorageSetupInitiatorActivity activity, IOConnectionInfo ioc, int requestCode,
             bool alwaysReturnSuccess)
         {
-            throw GetDeprecatedMessage();
+            _app.ShowMessage(activity.Activity, GetDeprecatedMessage(), MessageSeverity.Error);
+
         }
 
         public void PrepareFileUsage(Context ctx, IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            
         }
 
         public void OnCreate(IFileStorageSetupActivity activity, Bundle savedInstanceState)
         {
-            throw GetDeprecatedMessage();
+            
         }
 
         public void OnResume(IFileStorageSetupActivity activity)
         {
-            throw GetDeprecatedMessage();
+            
         }
 
         public void OnStart(IFileStorageSetupActivity activity)
         {
-            throw GetDeprecatedMessage();
         }
 
         public void OnActivityResult(IFileStorageSetupActivity activity, int requestCode, int resultCode, Intent data)
         {
-            throw GetDeprecatedMessage();
         }
 
         public string GetDisplayName(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            return "File using deprecated Microsoft API. Please update.";
         }
 
         public string CreateFilePath(string parent, string newFilename)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public IOConnectionInfo GetParentPath(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public IOConnectionInfo GetFilePath(IOConnectionInfo folderPath, string filename)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public bool IsPermanentLocation(IOConnectionInfo ioc)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
 
         public bool IsReadOnly(IOConnectionInfo ioc, OptionalOut<UiStringKey> reason = null)
         {
-            throw GetDeprecatedMessage();
+            throw GetDeprecatedException();
         }
     }
 }

--- a/src/Kp2aBusinessLogic/SelectStorageLocationActivityBase.cs
+++ b/src/Kp2aBusinessLogic/SelectStorageLocationActivityBase.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.OS;
 using Android.Widget;
 using Java.Net;
+using KeePass.Util;
 using KeePassLib.Serialization;
 using keepass2android.Io;
 
@@ -208,7 +209,7 @@ namespace keepass2android
 					{
 						return () =>
 							{
-								ShowErrorToast(_app.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message);
+								ShowErrorToast(_app.GetResourceString(UiStringKey.ErrorOcurred) + " " + ExceptionUtil.GetErrorMessage(e));
 								ReturnCancel();
 							};
 					}

--- a/src/Kp2aBusinessLogic/Utils/ExceptionUtil.cs
+++ b/src/Kp2aBusinessLogic/Utils/ExceptionUtil.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace KeePass.Util
+{
+    public class ExceptionUtil
+    {
+
+        public static string GetErrorMessage(Exception e)
+        {
+            string errorMessage = e.Message;
+            if (e is Java.Lang.Exception javaException)
+            {
+                errorMessage = javaException.LocalizedMessage ?? javaException.Message ?? errorMessage;
+            }
+
+            return errorMessage;
+        }
+
+    }
+}

--- a/src/Kp2aBusinessLogic/database/CheckDatabaseForChanges.cs
+++ b/src/Kp2aBusinessLogic/database/CheckDatabaseForChanges.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Android.App;
 using Android.Content;
+using KeePass.Util;
 using KeePassLib.Cryptography;
 using KeePassLib.Serialization;
 using KeePassLib.Utility;
@@ -65,7 +66,7 @@ namespace keepass2android
 			}
 			catch (Exception e)
 			{
-				Finish(false, e.Message);
+				Finish(false, ExceptionUtil.GetErrorMessage(e));
 			}
 
 		}

--- a/src/Kp2aBusinessLogic/database/KdbDatabaseFormat.cs
+++ b/src/Kp2aBusinessLogic/database/KdbDatabaseFormat.cs
@@ -10,6 +10,7 @@ using Com.Keepassdroid.Database.Exception;
 #endif
 using Com.Keepassdroid.Database.Save;
 using Java.Util;
+using KeePass.Util;
 using KeePassLib;
 using KeePassLib.Cryptography;
 using KeePassLib.Cryptography.Cipher;
@@ -82,15 +83,14 @@ namespace keepass2android
 			catch (Java.IO.FileNotFoundException e)
 			{
 				throw new FileNotFoundException(
-					e.Message, e);
+                    ExceptionUtil.GetErrorMessage(e), e);
 			}  
 			catch (Java.Lang.Exception e)
 			{
 				if (e.Message == "Invalid key!")
 					throw new InvalidCompositeKeyException();
-				throw new Exception(e.LocalizedMessage ??
-				e.Message ??
-				e.GetType().Name, e);
+				throw new Exception(ExceptionUtil.GetErrorMessage(e) ??
+                                                                  e.GetType().Name, e);
 			}
 			
 			HashOfLastStream = hashingStream.Hash;

--- a/src/Kp2aBusinessLogic/database/SynchronizeCachedDatabase.cs
+++ b/src/Kp2aBusinessLogic/database/SynchronizeCachedDatabase.cs
@@ -6,6 +6,7 @@ using Android.App;
 using Android.Content;
 using KeePassLib.Serialization;
 using keepass2android.Io;
+using KeePass.Util;
 
 namespace keepass2android
 {
@@ -109,7 +110,7 @@ namespace keepass2android
 			catch (Exception e)
 			{
                 Kp2aLog.LogUnexpectedError(e);
-				Finish(false, e.Message);
+				Finish(false, ExceptionUtil.GetErrorMessage(e));
 			}
 			
 		}

--- a/src/Kp2aBusinessLogic/database/edit/LoadDB.cs
+++ b/src/Kp2aBusinessLogic/database/edit/LoadDB.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
+using KeePass.Util;
 using keepass2android.database.edit;
 using KeePassLib;
 using KeePassLib.Keys;
@@ -103,10 +104,10 @@ namespace keepass2android
 			}
 			catch (AggregateException e)
 			{
-				string message = e.Message;
+				string message = ExceptionUtil.GetErrorMessage(e);
 				foreach (var innerException in e.InnerExceptions)
 				{
-					message = innerException.Message;
+					message = ExceptionUtil.GetErrorMessage(innerException);
 					// Override the message shown with the last (hopefully most recent) inner exception
 					Kp2aLog.LogUnexpectedError(innerException);
 				}
@@ -116,14 +117,14 @@ namespace keepass2android
 			catch (DuplicateUuidsException e)
 			{
 				Kp2aLog.Log(e.ToString());
-				Finish(false, _app.GetResourceString(UiStringKey.DuplicateUuidsError) + " " + e.Message + _app.GetResourceString(UiStringKey.DuplicateUuidsErrorAdditional), false, Exception);
+				Finish(false, _app.GetResourceString(UiStringKey.DuplicateUuidsError) + " " + ExceptionUtil.GetErrorMessage(e) + _app.GetResourceString(UiStringKey.DuplicateUuidsErrorAdditional), false, Exception);
 				return;
 			}
 			catch (Exception e)
 			{
 				if (!(e is InvalidCompositeKeyException))
 					Kp2aLog.LogUnexpectedError(e);
-				Finish(false, _app.GetResourceString(UiStringKey.ErrorOcurred) + " " + (e.Message ?? (e is FileNotFoundException ? _app.GetResourceString(UiStringKey.FileNotFound) :  "")), false, Exception);
+				Finish(false, _app.GetResourceString(UiStringKey.ErrorOcurred) + " " + (ExceptionUtil.GetErrorMessage(e) ?? (e is FileNotFoundException ? _app.GetResourceString(UiStringKey.FileNotFound) :  "")), false, Exception);
 				return;
 			}
 			

--- a/src/Kp2aBusinessLogic/database/edit/SaveDB.cs
+++ b/src/Kp2aBusinessLogic/database/edit/SaveDB.cs
@@ -29,6 +29,7 @@ using KeePassLib.Utility;
 using keepass2android.Io;
 using Debug = System.Diagnostics.Debug;
 using Exception = System.Exception;
+using KeePass.Util;
 
 namespace keepass2android
 {
@@ -187,7 +188,7 @@ namespace keepass2android
 			}
 */
 					Kp2aLog.LogUnexpectedError(e);
-					Finish(false, e.Message);
+					Finish(false, ExceptionUtil.GetErrorMessage(e));
 					return;
 				}
 			}
@@ -222,8 +223,8 @@ namespace keepass2android
 						catch (Exception e)
 						{
 							Kp2aLog.LogUnexpectedError(e);
-							Kp2aLog.Log("Error in worker thread of SaveDb: " + e);
-							Finish(false, e.Message);
+							Kp2aLog.Log("Error in worker thread of SaveDb: " + ExceptionUtil.GetErrorMessage(e));
+							Finish(false, ExceptionUtil.GetErrorMessage(e));
 						}
 						
 					});
@@ -233,7 +234,7 @@ namespace keepass2android
 			{
 				Kp2aLog.LogUnexpectedError(e);
 				Kp2aLog.Log("Error starting worker thread of SaveDb: "+e);
-				Finish(false, e.Message);
+				Finish(false, ExceptionUtil.GetErrorMessage(e));
 			}
 			
 		}

--- a/src/keepass2android-app/CreateNewFilename.cs
+++ b/src/keepass2android-app/CreateNewFilename.cs
@@ -28,7 +28,7 @@ namespace keepass2android
 			}
 			catch (Exception e)
 			{
-				Finish(false, e.Message);
+				Finish(false, Util.GetErrorMessage(e));
 			}
 
 		}

--- a/src/keepass2android-app/EntryActivity.cs
+++ b/src/keepass2android-app/EntryActivity.cs
@@ -796,7 +796,7 @@ namespace keepass2android
 	            {
 	                App.Kp2a.ShowMessage(this,
 	                    GetString(Resource.String.SaveAttachment_Failed, new Java.Lang.Object[] {filename})
-	                    + exWrite.Message,  MessageSeverity.Error);
+	                    + Util.GetErrorMessage(exWrite),  MessageSeverity.Error);
 	                return null;
 	            }
 	            finally
@@ -1305,7 +1305,7 @@ namespace keepass2android
 	            }
 	            catch (Exception ex)
 	            {
-	                Finish(false, ex.Message);
+	                Finish(false, Util.GetErrorMessage(ex));
 	            }
 
 

--- a/src/keepass2android-app/EntryEditActivity.cs
+++ b/src/keepass2android-app/EntryEditActivity.cs
@@ -715,7 +715,7 @@ namespace keepass2android
 			}
 			catch(Exception exAttach)
 			{
-				App.Kp2a.ShowMessage(this, GetString(Resource.String.AttachFailed)+" "+exAttach.Message,  MessageSeverity.Error);
+				App.Kp2a.ShowMessage(this, GetString(Resource.String.AttachFailed)+" "+ Util.GetErrorMessage(exAttach),  MessageSeverity.Error);
 			}
 			State.EntryModified = true;
 			PopulateBinaries();
@@ -1184,7 +1184,7 @@ namespace keepass2android
                     }))
                     .AddOnFailureListener(new FailureListener((e) =>
                     {
-                        Console.WriteLine($"Scan failed: {e.Message}");
+                        Console.WriteLine($"Scan failed: {Util.GetErrorMessage(e)}");
                     }));
 
 

--- a/src/keepass2android-app/ExportDatabaseActivity.cs
+++ b/src/keepass2android-app/ExportDatabaseActivity.cs
@@ -140,7 +140,7 @@ namespace keepass2android
 				}
 				catch (Exception ex)
 				{
-					Finish(false, ex.Message);
+					Finish(false, Util.GetErrorMessage(ex));
 				}
 
 

--- a/src/keepass2android-app/FileSelectHelper.cs
+++ b/src/keepass2android-app/FileSelectHelper.cs
@@ -128,7 +128,7 @@ namespace keepass2android
 					catch (Exception e)
 					{
 						toastMsg = ctx.GetString(Resource.String.private_key_save_failed,
-							new Java.Lang.Object[] { e.Message });
+							new Java.Lang.Object[] { Util.GetErrorMessage(e)});
                         severity = MessageSeverity.Error;
 
                     }

--- a/src/keepass2android-app/GeneratePasswordActivity.cs
+++ b/src/keepass2android-app/GeneratePasswordActivity.cs
@@ -543,7 +543,7 @@ namespace keepass2android
             }
             catch (Exception e) 
             {
-				App.Kp2a.ShowMessage(this, e.Message,  MessageSeverity.Error);
+				App.Kp2a.ShowMessage(this, Util.GetErrorMessage(e),  MessageSeverity.Error);
 			}
 			
 			return password;

--- a/src/keepass2android-app/PasswordActivity.cs
+++ b/src/keepass2android-app/PasswordActivity.cs
@@ -310,7 +310,7 @@ namespace keepass2android
 		            catch (Exception e)
 		            {
 		                Kp2aLog.Log(e.ToString());
-		                App.Kp2a.ShowMessage(this, "Error: " + e.Message,  MessageSeverity.Error);
+		                App.Kp2a.ShowMessage(this, "Error: " + Util.GetErrorMessage(e),  MessageSeverity.Error);
 		                return;
 		            }
 
@@ -1485,7 +1485,7 @@ namespace keepass2android
 				catch (Exception e)
 				{
 					Kp2aLog.LogUnexpectedError(e);
-					errorMessage = e.Message;
+					errorMessage = Util.GetErrorMessage(e);
 					return false;
 				}
 			}
@@ -2273,7 +2273,7 @@ namespace keepass2android
 				{
 					Kp2aLog.LogUnexpectedError(e);
 
-					ShowError( _act.GetString(Resource.String.ErrorUpdatingOtpAuxFile) + " " + e.Message);
+					ShowError( _act.GetString(Resource.String.ErrorUpdatingOtpAuxFile) + " " + Util.GetErrorMessage(e));
 				}
 
 

--- a/src/keepass2android-app/ShareUrlResults.cs
+++ b/src/keepass2android-app/ShareUrlResults.cs
@@ -121,7 +121,7 @@ namespace keepass2android
                 
             } catch (Exception e)
 			{
-				App.Kp2a.ShowMessage(this, e.Message,  MessageSeverity.Error);
+				App.Kp2a.ShowMessage(this, Util.GetErrorMessage(e),  MessageSeverity.Error);
 				SetResult(Result.Canceled);
 				Finish();
 				return;

--- a/src/keepass2android-app/SyncUtil.cs
+++ b/src/keepass2android-app/SyncUtil.cs
@@ -40,7 +40,7 @@ namespace keepass2android
                 catch (Exception e)
                 {
 
-                    Finish(false, e.Message);
+                    Finish(false, Util.GetErrorMessage(e));
                 }
 
 

--- a/src/keepass2android-app/Utils/Util.cs
+++ b/src/keepass2android-app/Utils/Util.cs
@@ -37,10 +37,12 @@ using Android.Util;
 using Android.Views.InputMethods;
 using AndroidX.Core.View.InputMethod;
 using Google.Android.Material.Dialog;
+using KeePass.Util;
 using keepass2android;
 using KeePassLib;
 using KeePassLib.Security;
 using KeePassLib.Serialization;
+using Org.Apache.Http.Util;
 using Uri = Android.Net.Uri;
 
 
@@ -196,6 +198,12 @@ namespace keepass2android
             ioc.UserName = i.GetStringExtra(prefix + KeyServerusername) ?? "";
             ioc.Password = i.GetStringExtra(prefix + KeyServerpassword) ?? "";
             ioc.CredSaveMode = (IOCredSaveMode)i.GetIntExtra(prefix + KeyServercredmode, (int)IOCredSaveMode.NoSave);
+        }
+
+
+        public static string GetErrorMessage(Exception e)
+        {
+            return ExceptionUtil.GetErrorMessage(e);
         }
 
         public static Bitmap DrawableToBitmap(Drawable drawable)
@@ -865,8 +873,6 @@ namespace keepass2android
 
             entry.Strings.Set(prefix + c, new ProtectedString(false, url));
         }
-
-
     }
 }
 

--- a/src/keepass2android-app/app/App.cs
+++ b/src/keepass2android-app/app/App.cs
@@ -836,7 +836,7 @@ namespace keepass2android
 							new DropboxAppFolderFileStorage(LocaleManager.LocalizedAppContext, this),
                             GoogleApiAvailability.Instance.IsGooglePlayServicesAvailable(LocaleManager.LocalizedAppContext)==ConnectionResult.Success ? new GoogleDriveFileStorage(LocaleManager.LocalizedAppContext, this) : null,
                             GoogleApiAvailability.Instance.IsGooglePlayServicesAvailable(LocaleManager.LocalizedAppContext)==ConnectionResult.Success ? new GoogleDriveAppDataFileStorage(LocaleManager.LocalizedAppContext, this) : null,
-							new OneDriveFileStorage(),
+							new OneDriveFileStorage(this),
 						    new OneDrive2FullFileStorage(),
 						    new OneDrive2MyFilesFileStorage(),
 						    new OneDrive2AppFolderFileStorage(),
@@ -1043,9 +1043,9 @@ namespace keepass2android
 		}
 
 		private string GetErrorMessageForFileStorageException(Exception e)
-		{
-			string errorMessage = e.Message;
-			if (e is OfflineModeException)
+        {
+            var errorMessage = Util.GetErrorMessage(e);
+            if (e is OfflineModeException)
 				errorMessage = GetResourceString(UiStringKey.InOfflineMode);
 		    if (e is DocumentAccessRevokedException)
 		        errorMessage = GetResourceString(UiStringKey.DocumentAccessRevoked);
@@ -1054,7 +1054,7 @@ namespace keepass2android
 		}
 
 
-		public void CouldntOpenFromRemote(IOConnectionInfo ioc, Exception ex)
+        public void CouldntOpenFromRemote(IOConnectionInfo ioc, Exception ex)
 		{
 			var errorMessage = GetErrorMessageForFileStorageException(ex);
 			ShowToast(LocaleManager.LocalizedAppContext.GetString(Resource.String.CouldNotLoadFromRemote, errorMessage), MessageSeverity.Error);

--- a/src/keepass2android-app/fileselect/FileChooserFileProvider.cs
+++ b/src/keepass2android-app/fileselect/FileChooserFileProvider.cs
@@ -71,7 +71,7 @@ namespace keepass2android
 			catch (Exception e)
 			{
 				if (errorMessageBuilder != null)
-					errorMessageBuilder.Append(e.Message);
+					errorMessageBuilder.Append(Util.GetErrorMessage(e));
 				Kp2aLog.Log(e.ToString());
 				return null;
 			}

--- a/src/keepass2android-app/fileselect/FileSelectActivity.cs
+++ b/src/keepass2android-app/fileselect/FileSelectActivity.cs
@@ -487,7 +487,7 @@ namespace keepass2android
             catch (Exception e)
             {
                 Kp2aLog.LogUnexpectedError(e);
-                App.Kp2a.ShowMessage(this, "Error: " + e.Message,  MessageSeverity.Error);
+                App.Kp2a.ShowMessage(this, "Error: " + Util.GetErrorMessage(e),  MessageSeverity.Error);
                 Finish();
             }
 

--- a/src/keepass2android-app/search/SearchResults.cs
+++ b/src/keepass2android-app/search/SearchResults.cs
@@ -142,7 +142,7 @@ namespace keepass2android.search
                 }
             } catch (Exception e) {
 				Kp2aLog.LogUnexpectedError(e);
-				App.Kp2a.ShowMessage(this,e.Message,  MessageSeverity.Error);
+				App.Kp2a.ShowMessage(this, Util.GetErrorMessage(e),  MessageSeverity.Error);
 				Finish();
 				return;
 			}

--- a/src/keepass2android-app/search/SearchTotpResults.cs
+++ b/src/keepass2android-app/search/SearchTotpResults.cs
@@ -96,7 +96,7 @@ namespace keepass2android.search
             catch (Exception e)
             {
                 Kp2aLog.LogUnexpectedError(e);
-                App.Kp2a.ShowMessage(this, e.Message,  MessageSeverity.Error);
+                App.Kp2a.ShowMessage(this, Util.GetErrorMessage(e),  MessageSeverity.Error);
                 Finish();
                 return;
             }

--- a/src/keepass2android-app/services/AutofillBase/AutofillServiceBase.cs
+++ b/src/keepass2android-app/services/AutofillBase/AutofillServiceBase.cs
@@ -156,7 +156,7 @@ namespace keepass2android.services.AutofillBase
                 catch (Java.Lang.SecurityException e)
                 {
                     Log.Warn(CommonUtil.Tag, "Security exception handling request");
-                    callback.OnFailure(e.Message);
+                    callback.OnFailure(Util.GetErrorMessage(e));
                     return;
                 }
 
@@ -455,7 +455,7 @@ namespace keepass2android.services.AutofillBase
             }
             catch (Exception e)
             {
-                callback.OnFailure(e.Message);   
+                callback.OnFailure(Util.GetErrorMessage(e));   
             }
             
         }

--- a/src/keepass2android-app/settings/AppSettingsActivity.cs
+++ b/src/keepass2android-app/settings/AppSettingsActivity.cs
@@ -261,7 +261,7 @@ namespace keepass2android
                     {
                         return () =>
                         {
-                            App.Kp2a.ShowMessage(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message,  MessageSeverity.Error);
+                            App.Kp2a.ShowMessage(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + Util.GetErrorMessage(e),  MessageSeverity.Error);
                         };
                     }
 
@@ -357,7 +357,7 @@ namespace keepass2android
                     {
                         return () =>
                         {
-                            App.Kp2a.ShowMessage(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + e.Message,  MessageSeverity.Error);
+                            App.Kp2a.ShowMessage(Activity, App.Kp2a.GetResourceString(UiStringKey.ErrorOcurred) + " " + Util.GetErrorMessage(e),  MessageSeverity.Error);
                         };
                     }
 
@@ -628,7 +628,7 @@ namespace keepass2android
                             catch (Exception ex)
                             {
                                 Kp2aLog.LogUnexpectedError(ex);
-                                App.Kp2a.ShowMessage(LocaleManager.LocalizedAppContext, ex.Message,  MessageSeverity.Error);
+                                App.Kp2a.ShowMessage(LocaleManager.LocalizedAppContext, Util.GetErrorMessage(ex),  MessageSeverity.Error);
                             }
                         }
                     );

--- a/src/keepass2android-app/settings/ExportKeyfileActivity.cs
+++ b/src/keepass2android-app/settings/ExportKeyfileActivity.cs
@@ -53,7 +53,7 @@ namespace keepass2android
                 }
                 catch (Exception ex)
                 {
-                    Finish(false, ex.Message);
+                    Finish(false, Util.GetErrorMessage(ex));
                 }
 
 


### PR DESCRIPTION
Extract original message when showing "Java exception messages" consistently. Improve error handling in deprecated OneDrive API stub and avoid crash by no-longer throwing in Main-thread methods.

Closes #2837 