### PR TITLE
Experiments regarding bug biometric unlock of database lose key file config

### DIFF
--- a/src/keepass2android-app/keepass2android-app.csproj
+++ b/src/keepass2android-app/keepass2android-app.csproj
@@ -742,7 +742,7 @@
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.5" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.5" />
     <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.30" />
-    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.27" />
+    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.6" />
     <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout" Version="1.3.0" />
     <PackageReference Include="Xamarin.AndroidX.CursorAdapter" Version="1.0.0.31" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.7.2" />


### PR DESCRIPTION
According to https://github.com/dotnet/android-libraries?tab=readme-ov-file#binding-policies I wasn't expecting that upgrading from 1.1.0.6 to 1.1.0.27 would lead to behavior changes. As the issues reported, however, indicate that there is something wrong with the Biometrics behavior, I'm reverting back to 1.1.0.6 to check if that might lead to the previous working behavior.