### PR TITLE
Fix issues with Webdav connection:

### DIFF
--- a/src/keepass2android-app/Resources/values-cs/strings.xml
+++ b/src/keepass2android-app/Resources/values-cs/strings.xml
@@ -730,7 +730,7 @@
   <string name="hint_smb_credentials">Pokud chcete přistupovat k souborům z vašeho osobního počítače se systémem Windows, použijte jako adresu hostitele název počítače nebo místní IP adresu; jako doménu zadejte název počítače a jako uživatelské jméno a heslo zadejte přihlašovací údaje do systému Windows (často stejné jako pro váš účet Microsoft).</string>
   <string name="WarnFingerprintInvalidated">Varování! Biometrické ověření může být zneplatněno Androidem, např. po přidání nového otisku prstu do nastavení zařízení. Ujistěte se, že vždy víte, jak odemknout pomocí hlavního hesla!</string>
   <string name="webdav_chunked_upload_size_title">Velikost bloku pro nahrávání přes WebDav</string>
-  <string name="webdav_chunked_upload_size_summary">Velikost bloků při nahrávání na servery WebDav v bajtech. Použijte hodnotu 0 pro deaktivaci nahrávání po blocích.</string>
+  <string name="webdav_chunked_upload_size_summary">Velikost bloků při nahrávání na servery WebDav v bajtech.</string>
   <string-array name="ChangeLog_1_14">
     <item>Aktualizace na .net 9 a cílovou verzi SDK 35. To přináší průhledný stavový řádek v systému Android 15, protože nyní je výchozím nastavením režim od okraje k okraji.</item>
     <item>Drobná vylepšení uživatelského rozhraní</item>

--- a/src/keepass2android-app/Resources/values-da/strings.xml
+++ b/src/keepass2android-app/Resources/values-da/strings.xml
@@ -730,7 +730,7 @@
   <string name="hint_smb_credentials">Ønsker man at tilgå filer fra sin personlige Windows-computer, benyt computerens navn eller lokale IP-adresse som værts-URL; angiv computernavnet som domæne og Windows-login\'et (ofte det samme som Microsoft-kontoen) som brugernavn og adgangskode.</string>
   <string name="WarnFingerprintInvalidated">Advarsel! Biometrisk godkendelse kan ugyldiggøres af Android, f.eks. efter tilføjelse af et nyt fingeraftryk i dine enhedsindstillinger. Sørg for, at du altid ved, hvordan du låser op med din hovedadgangskode!</string>
   <string name="webdav_chunked_upload_size_title">Chunk-størrelse til WebDAV-upload</string>
-  <string name="webdav_chunked_upload_size_summary">Størrelse på chunks  i bytes ved upload til WebDAV-servere. Brug 0 til at deaktivere chunk-type upload.</string>
+  <string name="webdav_chunked_upload_size_summary">Størrelse på chunks  i bytes ved upload til WebDAV-servere. </string>
   <string-array name="ChangeLog_1_14">
     <item>Opdatering til .net 9 og Target SDK version 35. Dette kommer med gennemsigtig statusbjælke på Android 15, idet kant-til-kant er nu standard.</item>
     <item>Minor UI improvements</item>

--- a/src/keepass2android-app/Resources/values-de/strings.xml
+++ b/src/keepass2android-app/Resources/values-de/strings.xml
@@ -728,7 +728,7 @@ Anbei einige Tipps, die bei der Diagnose des Problems helfen können:\n
   <string name="hint_smb_credentials">Wenn Sie auf Dateien von Ihrem persönlichen Windows-Computer aus zugreifen möchten, verwenden Sie den Computernamen oder die lokale IP-Adresse als Host-URL; geben Sie den Computernamen als Domäne und das Windows-Login (oft identisch mit Ihrem Microsoft-Konto) als Benutzername und Passwort ein.</string>
   <string name="WarnFingerprintInvalidated">Achtung! Die biometrische Authentifizierung kann von Android ungültig gemacht werden, z. B. nach dem Hinzufügen eines neuen Fingerabdrucks in den Geräteeinstellungen. Bitte sicherstellen, dass jederzeit klar ist, wie mit dem eigenen Hauptpasswort entsperrt werden kann!</string>
   <string name="webdav_chunked_upload_size_title">Chunk-Größe für den WebDav-Upload</string>
-  <string name="webdav_chunked_upload_size_summary">Größe der Chunks beim Hochladen auf WebDav-Server in Bytes. Verwende 0, um den Upload in Chunks zu deaktivieren.</string>
+  <string name="webdav_chunked_upload_size_summary">Größe der Chunks beim Hochladen auf WebDav-Server in Bytes.</string>
   <string-array name="ChangeLog_1_14_net">
     <item>WebDav-Verbesserungen: Fehlerbehebung für die Ordnerauflistung; Unterstützung für chunked Uploads und Transaktionen</item>
     <item>Unterstützung für Samba/Windows-Netzwerkfreigaben hinzugefügt</item>

--- a/src/keepass2android-app/Resources/values-el/strings.xml
+++ b/src/keepass2android-app/Resources/values-el/strings.xml
@@ -727,7 +727,7 @@
   <string name="hint_smb_credentials">Αν θέλετε να αποκτήσετε πρόσβαση σε αρχεία από τον προσωπικό σας υπολογιστή με Windows, χρησιμοποιήστε το όνομα του υπολογιστή ή την τοπική διεύθυνση IP ως URL υποδοχής. Εισάγετε το όνομα υπολογιστή ως domain και τα στοιχεία του Windows login (συχνά ίδια με το λογαριασμό Microsoft) ως όνομα χρήστη και  συνθηματικό.</string>
   <string name="WarnFingerprintInvalidated">Προσοχή! Ο βιομετρικός έλεγχος ταυτότητας μπορεί να ακυρωθεί από το Android, π.χ. μετά την προσθήκη ενός νέου δακτυλικού αποτυπώματος στις ρυθμίσεις της συσκευής σας. Βεβαιωθείτε ότι ξέρετε πάντα πώς να ξεκλειδώσετε με το κύριο συνθηματικό!</string>
   <string name="webdav_chunked_upload_size_title">Μέγεθος ομάδας για μεταφόρτωση WebDav</string>
-  <string name="webdav_chunked_upload_size_summary">Μέγεθος ομάδας κατά τη μεταφόρτωση σε διακομιστές WebDav σε bytes. Χρησιμοποιήστε το 0 για να απενεργοποιήσετε την ομαδική μεταφόρτωση.</string>
+  <string name="webdav_chunked_upload_size_summary">Μέγεθος ομάδας κατά τη μεταφόρτωση σε διακομιστές WebDav σε bytes.</string>
   <string-array name="ChangeLog_1_14">
     <item></item>
     <item>Minor UI improvements</item>

--- a/src/keepass2android-app/Resources/values-fr/strings.xml
+++ b/src/keepass2android-app/Resources/values-fr/strings.xml
@@ -732,7 +732,7 @@
   <string name="hint_smb_credentials">Si vous voulez accéder aux fichiers depuis votre ordinateur personnel Windows, utilisez le nom de l\'ordinateur ou l\'adresse IP locale comme URL d\'hôte ; entrez le nom de l\'ordinateur en tant que domaine et la connexion Windows (souvent le même que votre compte Microsoft) que le nom d\'utilisateur et le mot de passe.</string>
   <string name="WarnFingerprintInvalidated">Attention ! L\'authentification biométrique peut être invalidée par Android, par ex. après avoir ajouté une nouvelle empreinte digitale dans les paramètres de votre appareil. Assurez-vous de toujours savoir comment déverrouiller avec votre mot de passe maître !</string>
   <string name="webdav_chunked_upload_size_title">Taille du bloc pour le téléchargement WebDav</string>
-  <string name="webdav_chunked_upload_size_summary">Taille des morceaux lors du téléchargement vers les serveurs WebDav, en octets. Utilisez 0 pour désactiver le téléchargement par morceaux.</string>
+  <string name="webdav_chunked_upload_size_summary">Taille des morceaux lors du téléchargement vers les serveurs WebDav, en octets.</string>
   <string-array name="ChangeLog_1_14">
     <item>Mise à jour vers .net 9 et Target SDK version 35. Ceci est livré avec une barre d\'état transparente sur Android 15 car le bord à bord est maintenant la valeur par défaut.</item>
     <item>Améliorations mineures de l\'interface</item>

--- a/src/keepass2android-app/Resources/values-it/strings.xml
+++ b/src/keepass2android-app/Resources/values-it/strings.xml
@@ -728,7 +728,7 @@ Ecco alcuni suggerimenti che ti potrebbero aiutare a diagnosticare il problema:\
   <string name="hint_smb_credentials">Se desideri accedere ai file del tuo computer Windows personale, usa il nome del computer o l\'indirizzo IP locale come URL host; digita il nome del computer come dominio e il login di Windows (spesso lo stesso dell\'account Microsoft) come nome utente e password.</string>
   <string name="WarnFingerprintInvalidated">Attenzione! L\'autenticazione biometrica può essere invalidata da Android, ad es. dopo aver aggiunto una nuova impronta digitale nelle impostazioni del dispositivo. Assicurati di sapere sempre come sbloccare con la tua password principale!</string>
   <string name="webdav_chunked_upload_size_title">Dimensione del blocco per il caricamento WebDav</string>
-  <string name="webdav_chunked_upload_size_summary">Dimensione dei blocchi durante il caricamento sui server WebDav in byte. Utilizzare 0 per disabilitare il caricamento in blocchi.</string>
+  <string name="webdav_chunked_upload_size_summary">Dimensione dei blocchi durante il caricamento sui server WebDav in byte.</string>
   <string-array name="ChangeLog_1_14">
     <item>Update to .net 9 and Target SDK version 35. This comes with transparent status bar on Android 15 because edge-to-edge is now the default.</item>
     <item>Miglioramenti minori dell\'interfaccia utente</item>

--- a/src/keepass2android-app/Resources/values-pt-rBR/strings.xml
+++ b/src/keepass2android-app/Resources/values-pt-rBR/strings.xml
@@ -734,7 +734,7 @@
   <string name="hint_smb_credentials">Se você deseja acessar arquivos do seu computador Windows pessoal, use o nome do computador ou o endereço IP local como URL do host; Digite o nome do computador como domínio e o login do Windows (geralmente o mesmo que sua conta da Microsoft) como nome de usuário e senha.</string>
   <string name="WarnFingerprintInvalidated">Alerta! Autenticação biométrica pode ser invalidada pelo Android, por exemplo: depois de adicionar uma nova digital nas configurações do seu dispositivo. Esteja certo de sempre saber como desbloquear com sua senha mestra!</string>
   <string name="webdav_chunked_upload_size_title">Tamanho do bloco para upload do WebDav</string>
-  <string name="webdav_chunked_upload_size_summary">Tamanho dos blocos ao fazer upload para servidores WebDav em bytes. Use 0 para desativar o upload em blocos.</string>
+  <string name="webdav_chunked_upload_size_summary">Tamanho dos blocos ao fazer upload para servidores WebDav em bytes.</string>
   <string-array name="ChangeLog_1_14">
     <item>Atualização para .NET 9 e Target SDK versão 35. Isso vem com a barra de status transparente no Android 15 porque agora é o padrão.</item>
     <item>Pequenas melhorias na interface do usuário</item>

--- a/src/keepass2android-app/Resources/values-sk/strings.xml
+++ b/src/keepass2android-app/Resources/values-sk/strings.xml
@@ -732,7 +732,7 @@
   <string name="hint_smb_credentials">Ak chcete získať prístup k súborom z PC s Windows, použite názov počítača alebo lokálnu IP adresu ako URL hostiteľa; zadajte názov počítača ako doménu a prihlasovacie údaje do Windows (častokrát rovnaké ako v konte Microsoft) ako meno používateľa a heslo.</string>
   <string name="WarnFingerprintInvalidated">Varovanie! Biometrická autentifikácia môže byť zneplatnená systémom Android, nap. po pridaní nového odtlačku prsta do nastavení zariadenia. Vždy sa uistite, že viete ako odomknúť zariadenia primárnym heslom.</string>
   <string name="webdav_chunked_upload_size_title">Veľkosť bloku pre upload WebDav</string>
-  <string name="webdav_chunked_upload_size_summary">Veľkosť blokov pri odosielaní na servery WebDav, v bajtoch. Ak chcete vypnúť odosielanie blokov, zadajte hodnotu 0.</string>
+  <string name="webdav_chunked_upload_size_summary">Veľkosť blokov pri odosielaní na servery WebDav, v bajtoch.</string>
   <string-array name="ChangeLog_1_14">
     <item>Aktualizácia na .net 9 a Target SDK verzie 35. Pribudol priehľadný stavový riadok v systéme Android 15, pretože predvolený režim je edge-to-edge.</item>
     <item>Menšie vylepšenia používateľského rozhrania</item>

--- a/src/keepass2android-app/Resources/values-zh/strings.xml
+++ b/src/keepass2android-app/Resources/values-zh/strings.xml
@@ -732,7 +732,7 @@
   <string name="hint_smb_credentials">如果要从个人 Windows 计算机访问文件，请将计算机名或本地 IP 地址用作主机 URL；输入计算机名作为域名，Windows 登录名（经常和微软账户名相同）作为用户名和密码。</string>
   <string name="WarnFingerprintInvalidated">警告!生物识别认证可能会被Android系统作废，例如在你的设备设置中添加一个新的指纹后。确保你总是知道如何用你的主密码解锁！</string>
   <string name="webdav_chunked_upload_size_title">WebDav 上传的块大小</string>
-  <string name="webdav_chunked_upload_size_summary">上传到 WebDav 服务器时字节为单位的块大小。0 表示停用分块上传。</string>
+  <string name="webdav_chunked_upload_size_summary">上传到 WebDav 服务器时字节为单位的块大小。</string>
   <string-array name="ChangeLog_1_14">
     <item>更新至 .net 9 和 Target SDK 版本 35。这在 Android 15 上带有透明状态栏，因为以无边框方式显示现在是默认设置。</item>
     <item>较小的用户界面改进</item>

--- a/src/keepass2android-app/Resources/values/strings.xml
+++ b/src/keepass2android-app/Resources/values/strings.xml
@@ -739,7 +739,9 @@
   <string name="hint_smb_credentials">If you want to access files from your personal Windows computer, use the computer name or local IP address as host URL; enter the computer name as domain and the Windows login (often the same as your Microsoft account) as username and password.</string>
   <string name="WarnFingerprintInvalidated">Warning! Biometric authentication can be invalidated by Android, e.g. after adding a new fingerprint in your device settings. Make sure you always know how to unlock with your master password!</string>
   <string name="webdav_chunked_upload_size_title">Chunk size for WebDav upload</string>
-  <string name="webdav_chunked_upload_size_summary">Size of chunks when uploading to WebDav servers in bytes. Use 0 to disable chunked upload.</string>
+  <string name="webdav_chunked_upload_enabled_title">Enable chunked upload for WebDav</string>
+  <string name="webdav_chunked_upload_enabled_summary">For WebDav servers that do not support uploading large files in a single request. When enabled, Keepass2Android uses standard WebDav chunking, not the Nextcloud chunking method.</string>
+  <string name="webdav_chunked_upload_size_summary">Size of chunks when uploading to WebDav servers in bytes.</string>
   <string name="cleartextTrafficPermitted_title">Allow clear-text network traffic in WebDav</string>
   <string name="cleartextTrafficPermitted_summary">HTTP connections are not secure. Only enable this if you have other security measures in place.</string>
 

--- a/src/keepass2android-app/Resources/xml/pref_app_file_handling.xml
+++ b/src/keepass2android-app/Resources/xml/pref_app_file_handling.xml
@@ -45,13 +45,20 @@
 		android:title="@string/UseFileTransactions_title"
 		android:key="@string/UseFileTransactions_key" />
 
-  <EditTextPreference
-    android:key="WebDavChunkedUploadSize_str"
-    android:title="@string/webdav_chunked_upload_size_title"
-    android:summary="@string/webdav_chunked_upload_size_title"
-		android:defaultValue="@integer/WebDavChunkedUploadSize_default"
-    android:inputType="number"
-     />
+	<CheckBoxPreference
+		android:enabled="true"
+		android:persistent="true"
+		android:summary="@string/webdav_chunked_upload_enabled_summary"
+		android:defaultValue="false"
+		android:title="@string/webdav_chunked_upload_enabled_title"
+		android:key="WebDavChunkedUploadEnabled" />
+		<EditTextPreference
+			android:key="WebDavChunkedUploadSize_str"
+			android:title="@string/webdav_chunked_upload_size_title"
+			android:summary="@string/webdav_chunked_upload_size_summary"
+			android:defaultValue="@integer/WebDavChunkedUploadSize_default"
+			android:inputType="number"
+			android:dependency="WebDavChunkedUploadEnabled" />
 
 	<CheckBoxPreference
 		android:enabled="true"

--- a/src/keepass2android-app/app/App.cs
+++ b/src/keepass2android-app/app/App.cs
@@ -1339,16 +1339,31 @@ namespace keepass2android
         }
 
 
-        public int WebDavChunkedUploadSize
-        {
-            get
-            {
-                return int.Parse(PreferenceManager.GetDefaultSharedPreferences(LocaleManager.LocalizedAppContext)
-                    .GetString("WebDavChunkedUploadSize_str",
-                        LocaleManager.LocalizedAppContext.Resources
-                            .GetInteger(Resource.Integer.WebDavChunkedUploadSize_default).ToString()));
-            }
-        }
+		/// <summary>
+		/// Returns the chunk size to be used for WebDav chunked uploads. 0 if chunked uploads are disabled.
+		/// </summary>
+		/// Note that NextCloud implements a non-standard chunked upload mechanism which is not compatible to other WebDav servers.
+		/// This is why this setting is disabled by default.
+		public int WebDavChunkedUploadSize
+		{
+			get
+			{
+				try
+				{
+					if (!PreferenceManager.GetDefaultSharedPreferences(LocaleManager.LocalizedAppContext)
+						.GetBoolean("WebDavChunkedUploadEnabled", false))
+						return 0;
+					return int.Parse(PreferenceManager.GetDefaultSharedPreferences(LocaleManager.LocalizedAppContext)
+					.GetString("WebDavChunkedUploadSize_str",
+						LocaleManager.LocalizedAppContext.Resources
+							.GetInteger(Resource.Integer.WebDavChunkedUploadSize_default).ToString()));
+				}
+				catch
+				{
+					return 0;
+				}
+			}
+		}
     }
 
 


### PR DESCRIPTION
 - fix issue with non-chunked upload which could lead to invalid data being uploaded
 - disable chunked upload by default and explain that it is not the same as Nextcloud chunking.
 - simplify http/cleartext check
 - improve preferences by adding a checkbox instead of 0/non-0

 closes #3024, #2987