### PR TITLE
Fix "Illegal seek" error when opening files

### DIFF
--- a/src/Kp2aBusinessLogic/Io/CachingFileStorage.cs
+++ b/src/Kp2aBusinessLogic/Io/CachingFileStorage.cs
@@ -303,7 +303,7 @@ namespace keepass2android.Io
 
 				using (HashingStreamEx cachedFile = new HashingStreamEx(File.Create(cachedFilePath), true, new SHA256Managed()))
 				{
-					remoteFile.CopyTo(cachedFile);
+                    MemUtil.CopyStream(remoteFile, cachedFile);
 					cachedFile.Close();
 					fileHash = MemUtil.ByteArrayToHexString(cachedFile.Hash);
 				}
@@ -339,7 +339,7 @@ namespace keepass2android.Io
 				IWriteTransaction remoteTrans = _cachedStorage.OpenWriteTransaction(ioc, useFileTransaction))
 			{
 				Stream remoteStream = remoteTrans.OpenFile();
-				cachedData.CopyTo(remoteStream);
+				MemUtil.CopyStream(cachedData, remoteStream);
 				remoteStream.Close();
 				remoteTrans.CommitWrite();
 			}

--- a/src/Kp2aBusinessLogic/Io/IoUtil.cs
+++ b/src/Kp2aBusinessLogic/Io/IoUtil.cs
@@ -113,7 +113,7 @@ namespace keepass2android.Io
 			{
 				using (var writeStream = writeTransaction.OpenFile())
 				{
-					sourceStorage.OpenFileForRead(sourceIoc).CopyTo(writeStream);
+                    MemUtil.CopyStream(sourceStorage.OpenFileForRead(sourceIoc), writeStream);
 				}
 				writeTransaction.CommitWrite();
 			}


### PR DESCRIPTION
use MemUtil.CopyStream instead .CopyTo which has behavior incompatible to HashingStreamEx (depending on the base stream).

Closes #1768, closes #3026, closes #2007