### PR TITLE
Simple fix for http URLs

### DIFF
--- a/src/keepass2android-app/Resources/values/config.xml
+++ b/src/keepass2android-app/Resources/values/config.xml
@@ -40,7 +40,7 @@
     <string name="donate_url"><![CDATA[https://philipp.crocoll.net/donate.php?lang=%1$s&app=%2$s]]></string>
     <string name="homepage">https://github.com/PhilippC/keepass2android</string>
 	<string name="further_author_names">Alex Vallat, Ben Rush, Matthieu, Wiktor Ławski, gilbsgilbs, Chih-Hsuan Yen, DDoSolitary, marcoDallas, Rick Brown</string>
-	<string name="designer_names">Niki Hüttner (https://www.close-cut.de), Stefano Pignataro (https://www.spstudio.at)</string>
+	<string name="designer_names">Niki Hüttner (https://www.close-cut.de), Stefano Pignataro</string>
   <string name="supporter_names">Arno Welzel, Sebastián Ramírez, A. Finkhäuser, Makoto Mizukami</string>
     <string name="issues">https://github.com/PhilippC/keepass2android/issues</string>
     <string name="oi_filemanager_market">market://details?id=org.openintents.filemanager</string>


### PR DESCRIPTION
This PR updates two URLs from http to https and deletes one broken URL to align with current best practices. 

Changes
Updated http links to https:
https://www.close-cut.de
https://crowdin.net/project/keepass2android

Removed link:
http://www.spstudio.at

Notes
All updated endpoints already support https.
No functional changes expected beyond using the secure variant of the same URLs.