### PR TITLE
feat: support adding OTP to existing entries when scanning otpauth:// QR codes

### DIFF
--- a/src/keepass2android-app/EntryActivity.cs
+++ b/src/keepass2android-app/EntryActivity.cs
@@ -1585,6 +1585,35 @@ namespace keepass2android
 
     }
 
+    /// <summary>
+    /// Adds or overwrites the OTP configuration in the entry using the KeeWeb/KeePassXC "otp" field format.
+    /// </summary>
+    internal void AddOtpToEntry(string otpUri, Action<EntryActivity> finishAction)
+    {
+      PwEntry initialEntry = Entry.CloneDeep();
+
+      PwEntry newEntry = Entry;
+      newEntry.History = newEntry.History.CloneDeep();
+      newEntry.CreateBackup(null);
+
+      newEntry.Touch(true, false); // Touch *after* backup
+
+      // Set the "otp" field with the otpauth:// URI (KeeWeb/KeePassXC format)
+      newEntry.Strings.Set("otp", new ProtectedString(true, otpUri));
+
+      // Save the entry:
+      ActionOnOperationFinished closeOrShowError = new ActionInContextInstanceOnOperationFinished(ContextInstanceId, App.Kp2a, (success, message, context) =>
+      {
+        OnOperationFinishedHandler.DisplayMessage(this, message, true);
+        finishAction(context as EntryActivity);
+      });
+
+      OperationWithFinishHandler runnable = new UpdateEntry(App.Kp2a, initialEntry, newEntry, closeOrShowError);
+
+      BlockingOperationStarter pt = new BlockingOperationStarter(App.Kp2a, runnable);
+      pt.Run();
+    }
+
     public bool GetVisibilityForProtectedView(TextView protectedView)
     {
       if (protectedView == null)

--- a/src/keepass2android-app/OtpEntryResults.cs
+++ b/src/keepass2android-app/OtpEntryResults.cs
@@ -1,0 +1,229 @@
+/*
+This file is part of Keepass2Android, Copyright 2013 Philipp Crocoll. 
+
+  Keepass2Android is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Keepass2Android is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Keepass2Android.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using KeePassLib;
+
+namespace keepass2android
+{
+  /// <summary>
+  /// Activity to display search results when adding OTP to an existing entry.
+  /// Similar to ShareUrlResults but specialized for otpauth:// URI handling.
+  /// </summary>
+  [Activity(Label = "@string/otp_find_entry", ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden, Theme = "@style/Kp2aTheme_ActionBar", Exported = false)]
+  public class OtpEntryResults : GroupBaseActivity
+  {
+    public OtpEntryResults(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(javaReference, transfer)
+    {
+    }
+
+    public OtpEntryResults()
+    {
+    }
+
+    public static void Launch(Activity act, AddOtpToEntryTask task, ActivityLaunchMode launchMode)
+    {
+      Intent i = new Intent(act, typeof(OtpEntryResults));
+      task.ToIntent(i);
+      launchMode.Launch(act, i);
+    }
+
+    public override bool IsSearchResult
+    {
+      get { return true; }
+    }
+
+    protected override void OnCreate(Bundle savedInstanceState)
+    {
+      if (!App.Kp2a.DatabasesBackgroundModificationLock.TryEnterReadLock(TimeSpan.FromSeconds(5)))
+      {
+        App.Kp2a.ShowMessage(this, GetString(Resource.String.failed_to_access_database), MessageSeverity.Error);
+        Finish();
+        return;
+      }
+
+      base.OnCreate(savedInstanceState);
+
+      SetResult(Result.Canceled);
+
+      UpdateBottomBarElementVisibility(Resource.Id.select_other_entry, true);
+      UpdateBottomBarElementVisibility(Resource.Id.add_url_entry, true);
+
+      if (App.Kp2a.DatabaseIsUnlocked)
+      {
+        Query();
+      }
+    }
+
+    protected override void OnSaveInstanceState(Bundle outState)
+    {
+      base.OnSaveInstanceState(outState);
+      AppTask.ToBundle(outState);
+    }
+
+    private void Query()
+    {
+      try
+      {
+        var addOtpTask = AppTask as AddOtpToEntryTask;
+        if (addOtpTask == null)
+        {
+          Finish();
+          return;
+        }
+
+        string searchText = AddOtpToEntryTask.GetSearchTextFromOtpUri(addOtpTask.OtpUri);
+        Group = GetSearchResultsForOtp(searchText);
+      }
+      catch (Exception e)
+      {
+        App.Kp2a.ShowMessage(this, Util.GetErrorMessage(e), MessageSeverity.Error);
+        SetResult(Result.Canceled);
+        Finish();
+        return;
+      }
+
+      // If no results, show empty layout
+      if (Group == null || !Group.Entries.Any())
+      {
+        SetContentView(Resource.Layout.otp_entry_results_empty);
+      }
+
+      SetGroupTitle();
+
+      var listFragment = FragmentManager.FindFragmentById<GroupListFragment>(Resource.Id.list_fragment);
+      if (listFragment != null)
+      {
+        listFragment.ListAdapter = new PwGroupListAdapter(this, Group);
+      }
+
+      View selectOtherEntry = FindViewById(Resource.Id.select_other_entry);
+      View createNewEntry = FindViewById(Resource.Id.add_url_entry);
+
+      var otpTask = AppTask as AddOtpToEntryTask;
+
+      selectOtherEntry.Visibility = ViewStates.Visible;
+      selectOtherEntry.Click += (sender, e) =>
+      {
+        // Launch GroupActivity with the same AddOtpToEntryTask so user can browse/search
+        GroupActivity.Launch(this, otpTask, new ActivityLaunchModeRequestCode(0));
+      };
+
+      if (App.Kp2a.OpenDatabases.Any(db => db.CanWrite))
+      {
+        createNewEntry.Visibility = ViewStates.Visible;
+        createNewEntry.Click += (sender, e) =>
+        {
+          // Create a new entry with OTP pre-filled (original behavior)
+          GroupActivity.Launch(this,
+              new CreateEntryThenCloseTask
+              {
+                AllFields = Newtonsoft.Json.JsonConvert.SerializeObject(
+                    new Dictionary<string, string> { { "otp", otpTask.OtpUri } })
+              },
+              new ActivityLaunchModeRequestCode(0));
+          App.Kp2a.ShowMessage(this,
+              GetString(Resource.String.select_group_then_add,
+                  new Java.Lang.Object[] { GetString(Resource.String.add_entry) }),
+              MessageSeverity.Info);
+        };
+      }
+      else
+      {
+        createNewEntry.Visibility = ViewStates.Gone;
+      }
+
+      Util.MoveBottomBarButtons(Resource.Id.select_other_entry, Resource.Id.add_url_entry, Resource.Id.bottom_bar, this);
+    }
+
+    /// <summary>
+    /// Search for entries matching the OTP issuer/label text.
+    /// </summary>
+    public static PwGroup GetSearchResultsForOtp(string searchText)
+    {
+      PwGroup resultsGroup = null;
+      foreach (var db in App.Kp2a.OpenDatabases)
+      {
+        PwGroup resultsForThisDb = null;
+
+        if (!string.IsNullOrEmpty(searchText))
+        {
+          resultsForThisDb = db.SearchForText(searchText);
+        }
+
+        if (resultsForThisDb == null)
+        {
+          resultsForThisDb = new PwGroup(true, true) { Name = "Search Results" };
+        }
+
+        if (resultsGroup == null)
+        {
+          resultsGroup = resultsForThisDb;
+        }
+        else
+        {
+          foreach (var entry in resultsForThisDb.Entries)
+          {
+            resultsGroup.AddEntry(entry, false, false);
+          }
+        }
+      }
+
+      return resultsGroup;
+    }
+
+    public override bool OnSearchRequested()
+    {
+      Intent i = new Intent(this, typeof(SearchActivity));
+      this.AppTask.ToIntent(i);
+      i.SetFlags(ActivityFlags.ForwardResult);
+      StartActivity(i);
+      return true;
+    }
+
+    protected override int ContentResourceId
+    {
+      get { return Resource.Layout.otp_entry_results; }
+    }
+
+    public override bool EntriesBelongToCurrentDatabaseOnly
+    {
+      get { return false; }
+    }
+
+    public override ElementAndDatabaseId FullGroupId
+    {
+      get { return null; }
+    }
+
+    protected override void OnDestroy()
+    {
+      base.OnDestroy();
+      App.Kp2a.DatabasesBackgroundModificationLock.ExitReadLock();
+    }
+  }
+}

--- a/src/keepass2android-app/Resources/layout/otp_entry_results.xml
+++ b/src/keepass2android-app/Resources/layout/otp_entry_results.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:fitsSystemWindows="true"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="?android:attr/colorBackground">
+  <LinearLayout
+      android:id="@+id/top"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:orientation="horizontal" />
+  <RelativeLayout
+      android:id="@+id/bottom_bar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:layout_alignParentBottom="true"
+      android:baselineAligned="false">
+    <Button
+        android:id="@+id/select_other_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:text="@string/otp_select_other_entry"
+        style="@style/BottomBarButton" />
+    <Button
+        android:id="@+id/add_url_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:text="@string/otp_create_new_entry"
+        style="@style/BottomBarButton" />
+  </RelativeLayout>
+  <View
+      android:id="@+id/divider2"
+      android:layout_width="fill_parent"
+      android:layout_height="1dp"
+      android:layout_above="@id/bottom_bar"
+      android:background="#b8b8b8" />
+  <fragment
+          android:name="keepass2android.GroupListFragment"
+          android:id="@+id/list_fragment"
+                  android:layout_above="@id/divider2"
+        android:layout_below="@id/top"
+
+          android:layout_width="match_parent"
+          android:layout_height="match_parent" />
+
+
+</RelativeLayout>

--- a/src/keepass2android-app/Resources/layout/otp_entry_results_empty.xml
+++ b/src/keepass2android-app/Resources/layout/otp_entry_results_empty.xml
@@ -1,0 +1,57 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:fitsSystemWindows="true"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="?android:attr/colorBackground">
+  <LinearLayout
+      android:id="@+id/top"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:orientation="horizontal" />
+  <RelativeLayout
+      android:id="@+id/bottom_bar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:layout_alignParentBottom="true"
+      android:baselineAligned="false">
+    <Button
+        android:id="@+id/select_other_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:text="@string/otp_select_other_entry"
+        style="@style/BottomBarButton" />
+    <Button
+        android:id="@+id/add_url_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:text="@string/otp_create_new_entry"
+        style="@style/BottomBarButton" />
+  </RelativeLayout>
+  <View
+      android:id="@+id/divider2"
+      android:layout_width="fill_parent"
+      android:layout_height="1dp"
+      android:layout_above="@id/bottom_bar"
+      android:background="#b8b8b8" />
+
+  <TextView
+    android:id="@+id/no_results"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="12dp"
+    android:layout_below="@id/top"
+    android:text="@string/no_results" />
+
+  <ListView
+      android:id="@android:id/list"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_above="@id/divider2"
+      android:layout_below="@id/no_results"
+      android:paddingRight="8dp"
+      android:paddingLeft="8dp" />
+</RelativeLayout>

--- a/src/keepass2android-app/Resources/values-zh/strings.xml
+++ b/src/keepass2android-app/Resources/values-zh/strings.xml
@@ -1264,4 +1264,13 @@ Initial public release
   <string name="pref_enable_periodic_background_sync_summary">如启用，应用会定期同步解锁的数据库。这遵守上面的网络连接设置。</string>
   <string name="pref_periodic_background_sync_interval_title">定期后台同步间隔</string>
   <string name="pref_periodic_background_sync_interval_summary">设置分钟为单位的后台同步间隔</string>
+
+  <string name="otp_find_entry">查找 OTP 对应的记录</string>
+  <string name="otp_select_other_entry">选择其他记录</string>
+  <string name="otp_create_new_entry">新建记录</string>
+  <string name="otp_add_to_entry_title">添加 OTP 到记录？</string>
+  <string name="otp_add_to_entry_text">将扫描到的 OTP 配置添加到所选记录中？</string>
+  <string name="otp_overwrite_title">OTP 已存在</string>
+  <string name="otp_overwrite_text">此记录已有 OTP 配置，是否覆盖？</string>
+  <string name="overwrite">覆盖</string>
 </resources>

--- a/src/keepass2android-app/Resources/values/strings.xml
+++ b/src/keepass2android-app/Resources/values/strings.xml
@@ -1352,5 +1352,14 @@
 
   <string name="pref_periodic_background_sync_interval_title">Periodic background synchronization time interval</string>
   <string name="pref_periodic_background_sync_interval_summary">Set the interval for background synchronization in minutes.</string>
+
+  <string name="otp_find_entry">Find entry for OTP</string>
+  <string name="otp_select_other_entry">Select another entry</string>
+  <string name="otp_create_new_entry">Create new entry</string>
+  <string name="otp_add_to_entry_title">Add OTP to entry?</string>
+  <string name="otp_add_to_entry_text">Add the scanned OTP configuration to the selected entry?</string>
+  <string name="otp_overwrite_title">OTP already exists</string>
+  <string name="otp_overwrite_text">This entry already has an OTP configuration. Do you want to overwrite it?</string>
+  <string name="overwrite">Overwrite</string>
     
 </resources>

--- a/src/keepass2android-app/SelectCurrentDbActivity.cs
+++ b/src/keepass2android-app/SelectCurrentDbActivity.cs
@@ -323,12 +323,9 @@ namespace keepass2android
         {
           if (IsOtpUri(Intent.Data))
           {
-            AppTask = new CreateEntryThenCloseTask()
+            AppTask = new AddOtpToEntryTask()
             {
-              AllFields = Newtonsoft.Json.JsonConvert.SerializeObject(new Dictionary<string, string>()
-                            {
-                                { "otp", Intent.DataString }
-                            })
+              OtpUri = Intent.DataString
             };
           }
           else

--- a/src/keepass2android-app/app/AppTask.cs
+++ b/src/keepass2android-app/app/AppTask.cs
@@ -850,6 +850,133 @@ namespace keepass2android
     }
   }
 
+  /// <summary>
+  /// Task for adding OTP configuration to an existing entry or creating a new entry with OTP.
+  /// Launched when the user scans an otpauth:// QR code via the system camera.
+  /// </summary>
+  public class AddOtpToEntryTask : AppTask
+  {
+    public const string OtpUriKey = "OtpUri";
+
+    public string OtpUri { get; set; }
+
+    public override void Setup(Bundle b)
+    {
+      OtpUri = b.GetString(OtpUriKey);
+    }
+
+    public override IEnumerable<IExtra> Extras
+    {
+      get
+      {
+        yield return new StringExtra { Key = OtpUriKey, Value = OtpUri };
+      }
+    }
+
+    public override void LaunchFirstGroupActivity(Activity act)
+    {
+      OtpEntryResults.Launch(act, this, new ActivityLaunchModeRequestCode(0));
+    }
+
+    public override void CompleteOnCreateEntryActivity(EntryActivity activity, Thread notifyPluginsOnOpenThread)
+    {
+      if (App.Kp2a.CurrentDb.CanWrite == false || string.IsNullOrEmpty(OtpUri))
+      {
+        base.CompleteOnCreateEntryActivity(activity, notifyPluginsOnOpenThread);
+        return;
+      }
+
+      // Check if the entry already has OTP configuration
+      var pwEntryOutput = new PwEntryOutput(activity.Entry, App.Kp2a.CurrentDb);
+      bool hasExistingOtp = new Kp2aTotp().TryGetAdapter(pwEntryOutput) != null;
+
+      if (hasExistingOtp)
+      {
+        // Entry already has OTP — ask user to confirm overwrite
+        AskOverwriteOtpThenComplete(activity, notifyPluginsOnOpenThread);
+      }
+      else
+      {
+        // Entry has no OTP — ask user to confirm adding
+        AskAddOtpThenComplete(activity, notifyPluginsOnOpenThread);
+      }
+    }
+
+    private void AskAddOtpThenComplete(EntryActivity activity, Thread notifyPluginsOnOpenThread)
+    {
+      MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity);
+      builder.SetTitle(activity.GetString(Resource.String.otp_add_to_entry_title));
+      builder.SetMessage(activity.GetString(Resource.String.otp_add_to_entry_text));
+
+      builder.SetPositiveButton(activity.GetString(Resource.String.yes), (dlgSender, dlgEvt) =>
+      {
+        activity.AddOtpToEntry(OtpUri, (EntryActivity ctx) =>
+        {
+          ctx.Recreate();
+        });
+      });
+
+      builder.SetNegativeButton(activity.GetString(Resource.String.no), (dlgSender, dlgEvt) =>
+      {
+        base.CompleteOnCreateEntryActivity(activity, notifyPluginsOnOpenThread);
+      });
+
+      Dialog dialog = builder.Create();
+      dialog.Show();
+    }
+
+    private void AskOverwriteOtpThenComplete(EntryActivity activity, Thread notifyPluginsOnOpenThread)
+    {
+      MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity);
+      builder.SetTitle(activity.GetString(Resource.String.otp_overwrite_title));
+      builder.SetMessage(activity.GetString(Resource.String.otp_overwrite_text));
+
+      builder.SetPositiveButton(activity.GetString(Resource.String.overwrite), (dlgSender, dlgEvt) =>
+      {
+        activity.AddOtpToEntry(OtpUri, (EntryActivity ctx) =>
+        {
+          ctx.Recreate();
+        });
+      });
+
+      builder.SetNegativeButton(activity.GetString(Resource.String.cancel), (dlgSender, dlgEvt) =>
+      {
+        base.CompleteOnCreateEntryActivity(activity, notifyPluginsOnOpenThread);
+      });
+
+      Dialog dialog = builder.Create();
+      dialog.Show();
+    }
+
+    /// <summary>
+    /// Extracts a search keyword from the otpauth:// URI (issuer or label).
+    /// </summary>
+    public static string GetSearchTextFromOtpUri(string otpUri)
+    {
+      try
+      {
+        System.Uri uri = new System.Uri(otpUri);
+        var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        string issuer = query.Get("issuer");
+        if (!string.IsNullOrEmpty(issuer))
+          return issuer;
+
+        // fallback: extract from path, e.g. otpauth://totp/Issuer:user@example.com
+        string path = System.Uri.UnescapeDataString(uri.AbsolutePath).TrimStart('/');
+        if (path.Contains(":"))
+          return path.Substring(0, path.IndexOf(':'));
+
+        if (!string.IsNullOrEmpty(path))
+          return path;
+      }
+      catch (Exception)
+      {
+        // ignore parse errors
+      }
+      return null;
+    }
+  }
+
 
   /// <summary>
   /// Navigate to a folder and open a Task (appear in SearchResult)


### PR DESCRIPTION
## 📝 Description
Previously, scanning an otpauth:// QR code via the system camera could only create a new entry. This change introduces an OTP search results page (OtpEntryResults) that searches for matching entries based on the issuer/label from the URI, allowing users to either add OTP to an existing entry or create a new one. When the selected entry already has OTP configured, a confirmation dialog asks whether to overwrite it.

## 🔗 Related Issue
#2791 

## 🛠️ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## ✅ Checklist
*Before submitting this PR, please confirm the following:*

- [x] **My code follows the style guidelines of this project.**
- [x] **I have performed a self-review of my own (or any AI generated) code.**
- [ ] **I have added/updated tests that prove my fix is effective or that my feature works.**
- [x] **All new and existing tests passed locally.**
- [x] **I have commented my code, particularly in hard-to-understand areas.**
- [x] **I have built the app locally, verified that it builds and tested the changes thoroughly.**

---
## 📸 Screenshots/Videos (if applicable)
| ![IMG_20260208_013113](https://github.com/user-attachments/assets/f98be3f6-0941-49da-88e3-e1ab4ce50b72) | ![IMG_20260208_013125](https://github.com/user-attachments/assets/0ee1db74-5495-471c-9189-c339aa896524) | ![IMG_20260208_013135](https://github.com/user-attachments/assets/682112df-fb38-413f-93d1-fa5f3a53d9b2) | ![IMG_20260208_013146](https://github.com/user-attachments/assets/ed931e3c-d4b6-48fb-94f4-1010b4b2a510) |
|:---:|:---:|:---:|:---:|
