### PR TITLE
Make the password text field appear in TalkBack's swipe order. Closes #2902

### DIFF
--- a/src/keepass2android-app/Resources/layout/password.xml
+++ b/src/keepass2android-app/Resources/layout/password.xml
@@ -137,8 +137,7 @@
                                 android:inputType="textPassword"
                                 android:layout_weight="1"
                                 android:fontFamily="sans-serif"
-                                android:hint="@string/hint_login_pass"
-                              android:importantForAccessibility="no"/>
+                                android:hint="@string/hint_login_pass"/>
                             <LinearLayout
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"


### PR DESCRIPTION
## 📝 Description

The password text field is now accessible.

## 🔗 Related Issue

https://github.com/PhilippC/keepass2android/issues/2902

## 🛠️ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## ✅ Checklist
*Before submitting this PR, please confirm the following:*

- [x] **My code follows the style guidelines of this project.**
- [x] **I have performed a self-review of my own (or any AI generated) code.**
- [x] **I have added/updated tests that prove my fix is effective or that my feature works.**
- [x] **All new and existing tests passed locally.**
- [x] **I have commented my code, particularly in hard-to-understand areas.**
- [x] **I have built the app locally, verified that it builds and tested the changes thoroughly.**
