### PR TITLE
Preserve original file extension in WebDAV temporary files

### DIFF
--- a/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/WebDavStorage.java
+++ b/src/java/JavaFileStorage/app/src/main/java/keepass2android/javafilestorage/WebDavStorage.java
@@ -389,9 +389,24 @@ public class WebDavStorage extends JavaFileStorageBase {
 
         if (writeTransactional)
         {
-            String randomSuffix = ".tmp." + generateRandomHexString(8);
-            uploadFile(path + randomSuffix, data, false);
-            renameOrMoveWebDavResource(path+randomSuffix, path, true);
+            // Generate a unique temporary file suffix
+            String tempSuffix = ".tmp." + generateRandomHexString(8);
+            String tempPath;
+
+            // Preserve the original file extension for WebDAV providers that don't support
+            // changing extensions. Insert temp suffix before the extension instead of after it.
+            // Example: "file.kdbx" -> "file.tmp.abc12345.kdbx" (instead of "file.kdbx.tmp.abc12345")
+            int lastDot = path.lastIndexOf('.');
+            int lastSlash = path.lastIndexOf('/');
+            if (lastDot > lastSlash && lastDot >= 0) {
+                // File has an extension: insert temp suffix before the extension
+                tempPath = path.substring(0, lastDot) + tempSuffix + path.substring(lastDot);
+            } else {
+                // No extension: append temp suffix at the end
+                tempPath = path + tempSuffix;
+            }
+            uploadFile(tempPath, data, false);
+            renameOrMoveWebDavResource(tempPath, path, true);
             return;
         }
 


### PR DESCRIPTION
## 📝 Description

Some WebDAV providers do not allow changing file extensions. This change modifies the temporary file naming to insert the .tmp suffix before the extension instead of after it, e.g. file.kdbx becomes file.tmp.abc12345.kdbx instead of file.kdbx.tmp.abc12345.

## 🔗 Related Issue

None.

## 🛠️ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## ✅ Checklist
*Before submitting this PR, please confirm the following:*

- [x] **My code follows the style guidelines of this project.**
- [x] **I have performed a self-review of my own (or any AI generated) code.**
- [ ] **I have added/updated tests that prove my fix is effective or that my feature works.**
- [x] **All new and existing tests passed locally.**
- [x] **I have commented my code, particularly in hard-to-understand areas.**
- [x] **I have built the app locally, verified that it builds and tested the changes thoroughly.**

---
## 📸 Screenshots/Videos (if applicable)