### PR TITLE
Add built-in photo capture feature

### DIFF
--- a/src/keepass2android-app/CapturePhotoActivity.cs
+++ b/src/keepass2android-app/CapturePhotoActivity.cs
@@ -203,24 +203,33 @@ namespace keepass2android
     {
       var btnCapture = FindViewById<ImageButton>(Resource.Id.btn_capture)!;
       btnCapture.Enabled = false;                 // prevent double-tap
-      _imageCapture?.TakePicture(new MainThreadExecutor(), new InMemoryCaptureCallback(this));
+
+      // Snapshot the current display rotation so we can correct for it during
+      // encoding. CameraX 1.4.x always uses ROTATION_0 as its internal target
+      // rotation (because this activity never recreates), so its EXIF orientation
+      // tag is written for ROTATION_0. We apply the delta between the actual
+      // display rotation and ROTATION_0 during post-processing to ensure both
+      // portrait and landscape photos come out correctly oriented.
+#pragma warning disable CS0618 // DefaultDisplay deprecated in API 30
+      int displayRotation = (int)(WindowManager!.DefaultDisplay!.Rotation);
+#pragma warning restore CS0618
+      _imageCapture?.TakePicture(new MainThreadExecutor(), new InMemoryCaptureCallback(this, displayRotation));
     }
 
     /// <summary>
-    /// Called on the UI thread once the raw JPEG bytes are available.
     /// Spawns a background thread to compute the three compressed variants,
     /// then shows the size-selection dialog on the UI thread.
     /// </summary>
-    private void OnPhotoCaptured(byte[] rawJpeg)
+    private void OnPhotoCaptured(byte[] rawJpeg, int displayRotation)
     {
       ThreadPool.QueueUserWorkItem(_ =>
       {
         byte[]? smallJpeg = null, mediumJpeg = null, originalJpeg = null;
         try
         {
-          smallJpeg = ResizeAndEncode(rawJpeg, MaxPxSmall, QualitySmall);
-          mediumJpeg = ResizeAndEncode(rawJpeg, MaxPxMedium, QualityMedium);
-          originalJpeg = ResizeAndEncode(rawJpeg, int.MaxValue, QualityOriginal);
+          smallJpeg = ResizeAndEncode(rawJpeg, MaxPxSmall, QualitySmall, displayRotation);
+          mediumJpeg = ResizeAndEncode(rawJpeg, MaxPxMedium, QualityMedium, displayRotation);
+          originalJpeg = ResizeAndEncode(rawJpeg, int.MaxValue, QualityOriginal, displayRotation);
         }
         catch (Exception ex)
         {
@@ -282,14 +291,24 @@ namespace keepass2android
     // -----------------------------------------------------------------
 
     /// <summary>
-    /// Decodes the source JPEG, optionally scales it down so that its longest
-    /// side does not exceed <paramref name="maxPx"/>, then re-encodes in RAM.
+    /// Decodes the source JPEG, applies any EXIF rotation so the pixel data matches
+    /// the visual orientation (important for viewers that ignore EXIF, e.g. KeePassXC
+    /// on desktop), optionally scales it down so that its longest side does not exceed
+    /// <paramref name="maxPx"/>, then re-encodes as JPEG in RAM.
     /// Pass <see cref="int.MaxValue"/> for <paramref name="maxPx"/> to skip scaling.
     /// </summary>
-    private static byte[] ResizeAndEncode(byte[] jpegBytes, int maxPx, int quality)
+    private static byte[] ResizeAndEncode(byte[] jpegBytes, int maxPx, int quality, int displayRotation)
     {
       var bmp = BitmapFactory.DecodeByteArray(jpegBytes, 0, jpegBytes.Length)
                 ?? throw new InvalidOperationException("Failed to decode captured image.");
+
+      // Read EXIF orientation and rotate/flip the bitmap so the pixel data is
+      // already in the correct visual orientation. This ensures that applications
+      // that do not honour EXIF metadata (e.g. KeePassXC on desktop) display the
+      // image correctly.
+      // displayRotation is passed from the capture moment to compensate for CameraX
+      // always encoding EXIF as if targetRotation=ROTATION_0 (portrait).
+      bmp = ApplyExifOrientation(bmp, jpegBytes, displayRotation);
 
       if (Math.Max(bmp.Width, bmp.Height) > maxPx)
       {
@@ -316,6 +335,87 @@ namespace keepass2android
       return $"{bytes / (1024.0 * 1024.0):F1} MB";
     }
 
+    /// <summary>
+    /// Reads the EXIF orientation tag from <paramref name="jpegBytes"/> and returns a
+    /// new <see cref="Bitmap"/> with the pixels rotated/flipped to match the visual
+    /// orientation.  Returns the original bitmap unchanged when no correction is needed.
+    /// <paramref name="displayRotation"/> is the Surface.Rotation* value at capture time
+    /// (0=portrait, 1=landscape-90, 2=portrait-180, 3=landscape-270). CameraX always
+    /// writes EXIF as if targetRotation=ROTATION_0, so we subtract the actual display
+    /// rotation to get the true correction angle.
+    /// </summary>
+    private static Bitmap ApplyExifOrientation(Bitmap source, byte[] jpegBytes, int displayRotation)
+    {
+      int orientation;
+      try
+      {
+        using var stream = new MemoryStream(jpegBytes);
+        var exif = new Android.Media.ExifInterface(stream);
+        orientation = exif.GetAttributeInt(
+            Android.Media.ExifInterface.TagOrientation,
+            (int)Android.Media.Orientation.Normal);
+      }
+      catch
+      {
+        return source; // If EXIF read fails, return as-is.
+      }
+
+      var matrix = new Matrix();
+
+      // CameraX 1.4.x always encodes EXIF as if targetRotation=ROTATION_0 (portrait).
+      // The EXIF tag therefore represents the rotation from sensor space to portrait space,
+      // regardless of what the device was actually doing at capture time.
+      // We must subtract the actual display rotation (in degrees) from the EXIF correction
+      // so that the final pixels are in the true display orientation.
+      //   displayRotation: 0=portrait, 1=landscape-90°, 2=portrait-180°, 3=landscape-270°
+      int displayDeg = displayRotation * 90;
+
+      // Degrees to rotate the bitmap to go from sensor space to correct visual orientation.
+      int exifDeg = (Android.Media.Orientation)orientation switch
+      {
+        Android.Media.Orientation.Rotate90 => 90,
+        Android.Media.Orientation.Rotate180 => 180,
+        Android.Media.Orientation.Rotate270 => 270,
+        _ => 0,
+      };
+
+      // For flip cases we still need the matrix approach; handle them separately.
+      bool isFlip = (Android.Media.Orientation)orientation is
+          Android.Media.Orientation.FlipHorizontal or
+          Android.Media.Orientation.FlipVertical or
+          Android.Media.Orientation.Transpose or
+          Android.Media.Orientation.Transverse;
+
+      if (isFlip)
+      {
+        // For flip orientations don't try to compensate display rotation —
+        // these are rare (scanner/mirror modes) and never produced by the camera.
+        switch ((Android.Media.Orientation)orientation)
+        {
+          case Android.Media.Orientation.FlipHorizontal:
+            matrix.PreScale(-1f, 1f); break;
+          case Android.Media.Orientation.FlipVertical:
+            matrix.PreScale(1f, -1f); break;
+          case Android.Media.Orientation.Transpose:
+            matrix.PostRotate(90); matrix.PreScale(-1f, 1f); break;
+          case Android.Media.Orientation.Transverse:
+            matrix.PostRotate(270); matrix.PreScale(-1f, 1f); break;
+        }
+      }
+      else
+      {
+        // Net rotation = EXIF correction − display rotation (mod 360)
+        int netDeg = ((exifDeg - displayDeg) % 360 + 360) % 360;
+        if (netDeg == 0) return source;
+        matrix.PostRotate(netDeg);
+      }
+
+      var rotated = Bitmap.CreateBitmap(source, 0, 0, source.Width, source.Height, matrix, true);
+      if (!ReferenceEquals(rotated, source))
+        source.Recycle();
+      return rotated;
+    }
+
     // -----------------------------------------------------------------
     // Inner helpers
     // -----------------------------------------------------------------
@@ -327,14 +427,16 @@ namespace keepass2android
     private class InMemoryCaptureCallback : ImageCapture.OnImageCapturedCallback
     {
       private readonly CapturePhotoActivity _activity;
+      private readonly int _displayRotation;
 
       // Required JNI constructor for .NET-Android interop.
       protected InMemoryCaptureCallback(IntPtr javaRef, JniHandleOwnership transfer)
           : base(javaRef, transfer) { }
 
-      public InMemoryCaptureCallback(CapturePhotoActivity activity)
+      public InMemoryCaptureCallback(CapturePhotoActivity activity, int displayRotation)
       {
         _activity = activity;
+        _displayRotation = displayRotation;
       }
 
       public override void OnCaptureSuccess(IImageProxy image)
@@ -342,7 +444,7 @@ namespace keepass2android
         try
         {
           byte[] bytes = ExtractJpegBytes(image);
-          _activity.RunOnUiThread(() => _activity.OnPhotoCaptured(bytes));
+          _activity.RunOnUiThread(() => _activity.OnPhotoCaptured(bytes, _displayRotation));
         }
         finally
         {

--- a/src/keepass2android-app/CapturePhotoActivity.cs
+++ b/src/keepass2android-app/CapturePhotoActivity.cs
@@ -1,0 +1,421 @@
+// This file is part of Keepass2Android, Copyright 2026 Philipp Crocoll.
+//
+//   Keepass2Android is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   Keepass2Android is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with Keepass2Android.  If not, see <http://www.gnu.org/licenses/>.
+
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Graphics;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using AndroidX.Camera.Core;
+using AndroidX.Camera.Lifecycle;
+using AndroidX.Camera.View;
+using AndroidX.Core.App;
+using AndroidX.Core.Content;
+using AndroidX.Core.View;
+using Google.Android.Material.Dialog;
+using System;
+using System.IO;
+using System.Threading;
+
+namespace keepass2android
+{
+  /// <summary>
+  /// Full-screen camera capture activity that keeps the captured JPEG bytes entirely
+  /// in memory (never written to disk or the media gallery).
+  /// The bytes are returned to the caller via the static <see cref="CapturedPhotoBytes"/>
+  /// field; the generated filename is passed as an Intent extra.
+  /// </summary>
+  [Activity(
+      Label = "@string/capture_photo_title",
+      ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.Keyboard
+                           | ConfigChanges.KeyboardHidden | ConfigChanges.ScreenSize,
+      Theme = "@style/Kp2aTheme_BlueNoActionBar")]
+  public class CapturePhotoActivity : LifecycleAwareActivity
+  {
+    /// <summary>Key for the filename Intent extra returned on success.</summary>
+    public const string ExtraFilename = "capturedFilename";
+
+    /// <summary>
+    /// Holds the raw JPEG bytes captured in-memory. Set before SetResult(Ok)+Finish().
+    /// The caller is responsible for clearing this after reading.
+    /// A static field is used because Intent extras cannot reliably hold large byte arrays.
+    /// </summary>
+    public static byte[]? CapturedPhotoBytes;
+
+    private const int RequestCodeCameraPermission = 1001;
+
+    // Resize targets for the three size options.
+    private const int MaxPxSmall = 800;
+    private const int MaxPxMedium = 1600;
+    private const int QualitySmall = 70;
+    private const int QualityMedium = 85;
+    private const int QualityOriginal = 95;
+
+    private ProcessCameraProvider? _cameraProvider;
+    private ImageCapture? _imageCapture;
+    private int _lensFacing = CameraSelector.LensFacingBack;
+
+    // -----------------------------------------------------------------
+    // Activity lifecycle
+    // -----------------------------------------------------------------
+
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+      base.OnCreate(savedInstanceState);
+
+      // Go edge-to-edge so the camera preview fills the full screen including
+      // behind the system bars; we handle insets manually on the control bar.
+      WindowCompat.SetDecorFitsSystemWindows(Window!, false);
+
+      SetContentView(Resource.Layout.capture_photo);
+
+      // Apply navigation-bar inset as extra bottom padding on the control bar
+      // so that buttons never overlap the gesture handle or navigation buttons.
+      var controlBar = FindViewById<LinearLayout>(Resource.Id.camera_controls)!;
+      ViewCompat.SetOnApplyWindowInsetsListener(controlBar, new ControlBarInsetsListener());
+
+      FindViewById<ImageButton>(Resource.Id.btn_capture)!.Click += (_, _) => TakePhoto();
+      FindViewById<ImageButton>(Resource.Id.btn_flip_camera)!.Click += (_, _) => FlipCamera();
+      FindViewById<ImageButton>(Resource.Id.btn_cancel)!.Click += (_, _) =>
+      {
+        SetResult(Result.Canceled);
+        Finish();
+      };
+
+      if (ContextCompat.CheckSelfPermission(this, Android.Manifest.Permission.Camera)
+          == Permission.Granted)
+      {
+        StartCamera();
+      }
+      else
+      {
+        AndroidX.Core.App.ActivityCompat.RequestPermissions(
+            this,
+            new[] { Android.Manifest.Permission.Camera },
+            RequestCodeCameraPermission);
+      }
+    }
+
+    public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
+    {
+      base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+      if (requestCode == RequestCodeCameraPermission)
+      {
+        if (grantResults.Length > 0 && grantResults[0] == Permission.Granted)
+        {
+          StartCamera();
+        }
+        else
+        {
+          App.Kp2a.ShowMessage(this,
+              GetString(Resource.String.camera_permission_required),
+              MessageSeverity.Error);
+          SetResult(Result.Canceled);
+          Finish();
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------
+    // Camera setup
+    // -----------------------------------------------------------------
+
+    private void StartCamera()
+    {
+      var future = ProcessCameraProvider.GetInstance(this);
+      future.AddListener(
+          new Java.Lang.Runnable(() =>
+          {
+            _cameraProvider = (ProcessCameraProvider)future.Get();
+            BindCamera();
+          }),
+          new MainThreadExecutor());
+    }
+
+    private void BindCamera()
+    {
+      if (_cameraProvider == null) return;
+
+      var previewView = FindViewById<PreviewView>(Resource.Id.camera_preview)!;
+
+      var preview = new Preview.Builder().Build();
+      preview.SetSurfaceProvider(new MainThreadExecutor(), previewView.SurfaceProvider);
+
+      // CameraX 1.4.x OnImageCapturedCallback delivers JPEG on devices where the sensor
+      // natively produces JPEG, and falls back via YUV->Bitmap->JPEG when it does not.
+      _imageCapture = new ImageCapture.Builder().Build();
+
+      // Hide the flip button when a front camera is unavailable (e.g. some tablets).
+      bool hasFrontCamera;
+      try { hasFrontCamera = _cameraProvider.HasCamera(CameraSelector.DefaultFrontCamera); }
+      catch { hasFrontCamera = false; }
+      FindViewById<ImageButton>(Resource.Id.btn_flip_camera)!.Visibility =
+          hasFrontCamera ? ViewStates.Visible : ViewStates.Gone;
+
+      var cameraSelector = new CameraSelector.Builder()
+          .RequireLensFacing(_lensFacing)
+          .Build();
+
+      try
+      {
+        _cameraProvider.UnbindAll();
+        _cameraProvider.BindToLifecycle(
+            (AndroidX.Lifecycle.ILifecycleOwner)this,
+            cameraSelector,
+            preview,
+            _imageCapture);
+      }
+      catch (Exception ex)
+      {
+        Kp2aLog.LogUnexpectedError(ex);
+        App.Kp2a.ShowMessage(this, ex.Message ?? "Camera error", MessageSeverity.Error);
+      }
+    }
+
+    private void FlipCamera()
+    {
+      _lensFacing = _lensFacing == CameraSelector.LensFacingBack
+          ? CameraSelector.LensFacingFront
+          : CameraSelector.LensFacingBack;
+      BindCamera();
+    }
+
+    // -----------------------------------------------------------------
+    // Capture -> size-selection dialog
+    // -----------------------------------------------------------------
+
+    private void TakePhoto()
+    {
+      var btnCapture = FindViewById<ImageButton>(Resource.Id.btn_capture)!;
+      btnCapture.Enabled = false;                 // prevent double-tap
+      _imageCapture?.TakePicture(new MainThreadExecutor(), new InMemoryCaptureCallback(this));
+    }
+
+    /// <summary>
+    /// Called on the UI thread once the raw JPEG bytes are available.
+    /// Spawns a background thread to compute the three compressed variants,
+    /// then shows the size-selection dialog on the UI thread.
+    /// </summary>
+    private void OnPhotoCaptured(byte[] rawJpeg)
+    {
+      ThreadPool.QueueUserWorkItem(_ =>
+      {
+        byte[]? smallJpeg = null, mediumJpeg = null, originalJpeg = null;
+        try
+        {
+          smallJpeg = ResizeAndEncode(rawJpeg, MaxPxSmall, QualitySmall);
+          mediumJpeg = ResizeAndEncode(rawJpeg, MaxPxMedium, QualityMedium);
+          originalJpeg = ResizeAndEncode(rawJpeg, int.MaxValue, QualityOriginal);
+        }
+        catch (Exception ex)
+        {
+          Kp2aLog.LogUnexpectedError(ex);
+          // Graceful fallback: if re-encoding fails, use raw bytes for all options.
+          originalJpeg ??= rawJpeg;
+          smallJpeg ??= originalJpeg;
+          mediumJpeg ??= originalJpeg;
+        }
+
+        RunOnUiThread(() => ShowSizeSelectionDialog(smallJpeg!, mediumJpeg!, originalJpeg!));
+      });
+    }
+
+    private void ShowSizeSelectionDialog(byte[] smallJpeg, byte[] mediumJpeg, byte[] originalJpeg)
+    {
+      string[] items =
+      {
+                $"{GetString(Resource.String.capture_size_small)}  ({FormatBytes(smallJpeg.Length)})",
+                $"{GetString(Resource.String.capture_size_medium)}  ({FormatBytes(mediumJpeg.Length)})",
+                $"{GetString(Resource.String.capture_size_original)}  ({FormatBytes(originalJpeg.Length)})",
+            };
+
+      // SetMessage and SetItems are mutually exclusive in AlertDialog — using both
+      // suppresses the item list. The warning is shown as the title instead.
+      new MaterialAlertDialogBuilder(this)
+          .SetTitle(Resource.String.capture_attachment_size_warning)
+          .SetItems(items, (_, e) =>
+          {
+            byte[] chosen = e.Which switch
+            {
+              0 => smallJpeg,
+              1 => mediumJpeg,
+              _ => originalJpeg,
+            };
+            FinishWithBytes(chosen);
+          })
+          .SetNegativeButton(Android.Resource.String.Cancel, (_, _) =>
+          {
+            // Let the user retake the shot.
+            FindViewById<ImageButton>(Resource.Id.btn_capture)!.Enabled = true;
+          })
+          .SetCancelable(false)
+          .Show();
+    }
+
+    private void FinishWithBytes(byte[] jpeg)
+    {
+      CapturedPhotoBytes = jpeg;
+      var filename = $"photo_{Java.Lang.JavaSystem.CurrentTimeMillis()}.jpg";
+      var resultIntent = new Intent();
+      resultIntent.PutExtra(ExtraFilename, filename);
+      SetResult(Result.Ok, resultIntent);
+      Finish();
+    }
+
+    // -----------------------------------------------------------------
+    // Image helpers
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Decodes the source JPEG, optionally scales it down so that its longest
+    /// side does not exceed <paramref name="maxPx"/>, then re-encodes in RAM.
+    /// Pass <see cref="int.MaxValue"/> for <paramref name="maxPx"/> to skip scaling.
+    /// </summary>
+    private static byte[] ResizeAndEncode(byte[] jpegBytes, int maxPx, int quality)
+    {
+      var bmp = BitmapFactory.DecodeByteArray(jpegBytes, 0, jpegBytes.Length)
+                ?? throw new InvalidOperationException("Failed to decode captured image.");
+
+      if (Math.Max(bmp.Width, bmp.Height) > maxPx)
+      {
+        float scale = (float)maxPx / Math.Max(bmp.Width, bmp.Height);
+        var scaled = Bitmap.CreateScaledBitmap(
+            bmp,
+            (int)(bmp.Width * scale),
+            (int)(bmp.Height * scale),
+            true /* bilinear filter */);
+        bmp.Recycle();
+        bmp = scaled;
+      }
+
+      using var ms = new MemoryStream();
+      bmp.Compress(Bitmap.CompressFormat.Jpeg, quality, ms);
+      bmp.Recycle();
+      return ms.ToArray();
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+      if (bytes < 1024L) return $"{bytes} B";
+      if (bytes < 1024L * 1024L) return $"{bytes / 1024.0:F1} KB";
+      return $"{bytes / (1024.0 * 1024.0):F1} MB";
+    }
+
+    // -----------------------------------------------------------------
+    // Inner helpers
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// CameraX in-memory capture callback. Keeps JPEG bytes in RAM — nothing is
+    /// written to any file or media store.
+    /// </summary>
+    private class InMemoryCaptureCallback : ImageCapture.OnImageCapturedCallback
+    {
+      private readonly CapturePhotoActivity _activity;
+
+      // Required JNI constructor for .NET-Android interop.
+      protected InMemoryCaptureCallback(IntPtr javaRef, JniHandleOwnership transfer)
+          : base(javaRef, transfer) { }
+
+      public InMemoryCaptureCallback(CapturePhotoActivity activity)
+      {
+        _activity = activity;
+      }
+
+      public override void OnCaptureSuccess(IImageProxy image)
+      {
+        try
+        {
+          byte[] bytes = ExtractJpegBytes(image);
+          _activity.RunOnUiThread(() => _activity.OnPhotoCaptured(bytes));
+        }
+        finally
+        {
+          image.Close();
+        }
+      }
+
+      /// <summary>
+      /// Extracts raw JPEG bytes from the ImageProxy.
+      /// When the sensor delivers JPEG natively, <c>planes[0].Buffer</c> contains
+      /// the complete JPEG stream and is copied directly. For other formats
+      /// (e.g. YUV_420_888 on some devices), the image is decoded to a Bitmap
+      /// and re-encoded in RAM — still never touching disk.
+      /// </summary>
+      private static byte[] ExtractJpegBytes(IImageProxy image)
+      {
+        if (image.Format == (int)ImageFormatType.Jpeg)
+        {
+          // Fast path: the buffer is already a complete JPEG.
+          var buffer = image.GetPlanes()[0].Buffer;
+          var bytes = new byte[buffer.Remaining()];
+          buffer.Get(bytes);
+          return bytes;
+        }
+
+        // Fallback for YUV or other sensor formats: decode to Bitmap, compress in RAM.
+        var bitmap = image.ToBitmap();
+        using var ms = new MemoryStream();
+        bitmap.Compress(Bitmap.CompressFormat.Jpeg, 95, ms);
+        bitmap.Recycle();
+        return ms.ToArray();
+      }
+
+      public override void OnError(ImageCaptureException exception)
+      {
+        Kp2aLog.LogUnexpectedError(exception);
+        _activity.RunOnUiThread(() =>
+        {
+          _activity.FindViewById<ImageButton>(Resource.Id.btn_capture)!.Enabled = true;
+          App.Kp2a.ShowMessage(
+                      _activity,
+                      exception.Message ?? "Camera capture failed",
+                      MessageSeverity.Error);
+        });
+      }
+    }
+
+    /// <summary>
+    /// Applies the navigation-bar inset as extra bottom padding on the control bar
+    /// so that buttons never overlap the gesture handle or navigation buttons.
+    /// The base 12 dp padding is preserved on all four sides.
+    /// </summary>
+    private class ControlBarInsetsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+    {
+      public WindowInsetsCompat OnApplyWindowInsets(View v, WindowInsetsCompat insets)
+      {
+        var bars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+        int dp12 = (int)(12 * v.Resources!.DisplayMetrics!.Density);
+        v.SetPadding(dp12, dp12, dp12, dp12 + bars.Bottom);
+        return insets;
+      }
+    }
+
+    /// <summary>
+    /// Simple IExecutor that always runs on the Android main (UI) thread.
+    /// Used to drive the CameraX futures and capture callbacks on the main thread.
+    /// </summary>
+    private class MainThreadExecutor : Java.Lang.Object, Java.Util.Concurrent.IExecutor
+    {
+      public void Execute(Java.Lang.IRunnable runnable)
+      {
+        new Handler(Looper.MainLooper).Post(() => runnable.Run());
+      }
+    }
+  }
+}

--- a/src/keepass2android-app/EntryEditActivity.cs
+++ b/src/keepass2android-app/EntryEditActivity.cs
@@ -935,12 +935,85 @@ namespace keepass2android
         AddBinary(filename, true);
     }
 
+    /// <summary>
+    /// Variant of <see cref="AddBinaryOrAsk"/> for bytes that are already in memory
+    /// (e.g. an in-app camera capture). Shows the same overwrite/rename dialog.
+    /// </summary>
+    void AddBinaryFromBytesOrAsk(string filename, byte[] bytes)
+    {
+      if (State.Entry.Binaries.Get(filename) != null)
+      {
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this);
+        builder.SetTitle(GetString(Resource.String.AskOverwriteBinary_title));
+        builder.SetMessage(GetString(Resource.String.AskOverwriteBinary));
+        builder.SetPositiveButton(GetString(Resource.String.AskOverwriteBinary_yes), (dlgSender, dlgEvt) =>
+        {
+          AddBinaryFromBytes(filename, bytes, true);
+        });
+        builder.SetNegativeButton(GetString(Resource.String.AskOverwriteBinary_no), (dlgSender, dlgEvt) =>
+        {
+          AddBinaryFromBytes(filename, bytes, false);
+        });
+        builder.SetNeutralButton(GetString(Android.Resource.String.Cancel), (dlgSender, dlgEvt) => { });
+        builder.Create().Show();
+      }
+      else
+      {
+        AddBinaryFromBytes(filename, bytes, true);
+      }
+    }
+
+    /// <summary>
+    /// Stores <paramref name="bytes"/> directly as a <see cref="ProtectedBinary"/> attachment.
+    /// When <paramref name="overwrite"/> is false the filename is made unique by appending a counter.
+    /// </summary>
+    void AddBinaryFromBytes(string filename, byte[] bytes, bool overwrite)
+    {
+      string strItem = filename;
+      if (!overwrite)
+      {
+        string strBase = KeePassLib.Utility.UrlUtil.StripExtension(strItem);
+        string strExt = "." + KeePassLib.Utility.UrlUtil.GetExtension(strItem);
+        int nTry = 0;
+        while (true)
+        {
+          string strNewName = strBase + nTry.ToString(System.Globalization.CultureInfo.InvariantCulture) + strExt;
+          if (State.Entry.Binaries.Get(strNewName) == null)
+          {
+            strItem = strNewName;
+            break;
+          }
+          ++nTry;
+        }
+      }
+      try
+      {
+        State.Entry.Binaries.Set(strItem, new KeePassLib.Security.ProtectedBinary(false, bytes));
+      }
+      catch (Exception exAttach)
+      {
+        App.Kp2a.ShowMessage(this,
+          GetString(Resource.String.AttachFailed) + " " + Util.GetErrorMessage(exAttach),
+          MessageSeverity.Error);
+      }
+      State.EntryModified = true;
+      PopulateBinaries();
+    }
+
     protected override void OnResume()
     {
       if (_uriToAddOrAsk != null)
       {
         AddBinaryOrAsk(_uriToAddOrAsk);
         _uriToAddOrAsk = null;
+      }
+      if (_cameraPhotoBytes != null)
+      {
+        var bytes = _cameraPhotoBytes;
+        var filename = _cameraPhotoFilename ?? "photo.jpg";
+        _cameraPhotoBytes = null;
+        _cameraPhotoFilename = null;
+        AddBinaryFromBytesOrAsk(filename, bytes);
       }
       base.OnResume();
     }
@@ -1401,6 +1474,17 @@ namespace keepass2android
             }
             _uriToAddOrAsk = uri; //we can't launch a dialog in onActivityResult, so delay this to onResume		
           }
+          else if (requestCode == Intents.RequestCodeCameraCapture)
+          {
+            // Transfer bytes via static field – Intent extras have a 1 MB IPC limit.
+            var photoBytes = CapturePhotoActivity.CapturedPhotoBytes;
+            CapturePhotoActivity.CapturedPhotoBytes = null;
+            if (photoBytes != null)
+            {
+              _cameraPhotoBytes = photoBytes;
+              _cameraPhotoFilename = data?.GetStringExtra(CapturePhotoActivity.ExtraFilename) ?? "photo.jpg";
+            }
+          }
           return;
         case Result.Canceled:
           return;
@@ -1466,8 +1550,29 @@ namespace keepass2android
         addBinaryButton.Enabled = !State.Entry.Binaries.Any();
       addBinaryButton.Click += (sender, e) =>
       {
-        Util.ShowBrowseDialog(this, Intents.RequestCodeFileBrowseForBinary, false, true /*force OpenDocument if available, GetContent is not well support starting with Android 7 */);
-
+        // Offer both a file browser and an in-app camera (no disk/gallery write).
+        var items = new string[]
+        {
+          GetString(Resource.String.attach_browse_file),
+          GetString(Resource.String.attach_take_photo)
+        };
+        new Google.Android.Material.Dialog.MaterialAlertDialogBuilder(this)
+          .SetTitle(Resource.String.add_binary)
+          .SetItems(items, (dlgSender, dlgArgs) =>
+          {
+            if (dlgArgs.Which == 0)
+            {
+              Util.ShowBrowseDialog(this, Intents.RequestCodeFileBrowseForBinary, false,
+                true /*force OpenDocument if available*/);
+            }
+            else
+            {
+              StartActivityForResult(
+                new Intent(this, typeof(CapturePhotoActivity)),
+                Intents.RequestCodeCameraCapture);
+            }
+          })
+          .Show();
       };
 
       binariesGroup.AddView(addBinaryButton, layoutParams);
@@ -1581,6 +1686,8 @@ namespace keepass2android
     private string[] _additionalKeys = null;
     private List<View> _editModeHiddenViews;
     private Uri _uriToAddOrAsk;
+    private byte[]? _cameraPhotoBytes;
+    private string? _cameraPhotoFilename;
 
     public string[] AdditionalKeys
     {

--- a/src/keepass2android-app/Manifests/AndroidManifest_debug.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_debug.xml
@@ -282,6 +282,11 @@ The scheme=file is still there for old OS devices. It's also queried by apps lik
     <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_W" android:value="426.0dip" />
     <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_H" android:value="360.0dip" />
   </application>
+  <!-- Camera permission for in-app attachment photo capture (runtime permission on API 23+) -->
+  <uses-permission android:name="android.permission.CAMERA" />
+  <!-- required="false": app works without a camera; feature only shown on devices that have one -->
+  <uses-feature android:name="android.hardware.camera" android:required="false" />
+  <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.INTERNET" />

--- a/src/keepass2android-app/Manifests/AndroidManifest_light.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_light.xml
@@ -66,6 +66,10 @@
 			</intent-filter>
 		</activity>
 	</application>
+	<!-- Camera permission for in-app attachment photo capture (runtime permission on API 23+) -->
+	<uses-permission android:name="android.permission.CAMERA" />
+	<uses-feature android:name="android.hardware.camera" android:required="false" />
+	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.INTERNET" />

--- a/src/keepass2android-app/Manifests/AndroidManifest_net.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_net.xml
@@ -310,7 +310,10 @@ The scheme=file is still there for old OS devices. It's also queried by apps lik
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />  
 
+  <!-- Camera permission for in-app attachment photo capture (runtime permission on API 23+) -->
+  <uses-permission android:name="android.permission.CAMERA" />
   <uses-feature android:name="android.hardware.camera" android:required="false" />
+  <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
   <!-- Samsung Pass permission -->
   <uses-permission android:name="com.samsung.android.providers.context.permission.WRITE_USE_APP_FEATURE_SURVEY" />

--- a/src/keepass2android-app/Manifests/AndroidManifest_nonet.xml
+++ b/src/keepass2android-app/Manifests/AndroidManifest_nonet.xml
@@ -281,7 +281,10 @@ The scheme=file is still there for old OS devices. It's also queried by apps lik
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
+  <!-- Camera permission for in-app attachment photo capture (runtime permission on API 23+) -->
+  <uses-permission android:name="android.permission.CAMERA" />
   <uses-feature android:name="android.hardware.camera" android:required="false" />
+  <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
   <!-- Samsung Pass permission -->
   <uses-permission android:name="com.samsung.android.providers.context.permission.WRITE_USE_APP_FEATURE_SURVEY" />

--- a/src/keepass2android-app/Resources/layout/capture_photo.xml
+++ b/src/keepass2android-app/Resources/layout/capture_photo.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  In-app camera capture layout. Uses CameraX PreviewView so no photo is ever
+  written to external storage or the media gallery.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <!-- Live camera preview - fills the entire screen -->
+    <androidx.camera.view.PreviewView
+        android:id="@+id/camera_preview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!-- Bottom control bar overlaid on the preview -->
+    <LinearLayout
+        android:id="@+id/camera_controls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:background="#CC000000"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <!-- Cancel / close -->
+        <ImageButton
+            android:id="@+id/btn_cancel"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/cancel"
+            android:padding="12dp"
+            android:src="@drawable/baseline_close_24"
+            android:tint="@android:color/white" />
+
+        <!-- Shutter / capture (larger, center) -->
+        <ImageButton
+            android:id="@+id/btn_capture"
+            android:layout_width="0dp"
+            android:layout_height="80dp"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/capture_photo_title"
+            android:padding="8dp"
+            android:src="@drawable/baseline_camera_alt_24"
+            android:tint="@android:color/white" />
+
+        <!-- Flip camera front/back -->
+        <ImageButton
+            android:id="@+id/btn_flip_camera"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/capture_flip_camera"
+            android:padding="12dp"
+            android:src="@drawable/baseline_sync_24"
+            android:tint="@android:color/white" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/src/keepass2android-app/Resources/values/strings.xml
+++ b/src/keepass2android-app/Resources/values/strings.xml
@@ -374,6 +374,15 @@
   <string name="field_value">Field value</string>
   <string name="protection">Protected field</string>
   <string name="add_binary">Add file attachment</string>
+  <string name="attach_browse_file">Browse file…</string>
+  <string name="attach_take_photo">Take photo…</string>
+  <string name="capture_photo_title">Take photo</string>
+  <string name="capture_flip_camera">Flip camera</string>
+  <string name="camera_permission_required">Camera permission is required to take a photo.</string>
+  <string name="capture_attachment_size_warning">Select photo size</string>
+  <string name="capture_size_small">Small</string>
+  <string name="capture_size_medium">Medium</string>
+  <string name="capture_size_original">Original</string>
   <string name="add_extra_string">Add additional string</string>
   <string name="configure_totp">Configure TOTP</string>
   <string name="totp_secret_key">Secret key</string>

--- a/src/keepass2android-app/intents/Intents.cs
+++ b/src/keepass2android-app/intents/Intents.cs
@@ -58,6 +58,7 @@ namespace keepass2android
     public const int RequestCodeFileBrowseForCreate = 37322;
     public const int RequestCodeFileBrowseForBinary = 37323;
     public const int RequestCodeFileBrowseForKeyfile = 37324;
+    public const int RequestCodeCameraCapture = 37325;
 
     public const String ShowNotification = "keepass2android.show_notification";
     public const String UpdateKeyboard = "keepass2android.update_keyboard";

--- a/src/keepass2android-app/keepass2android-app.csproj
+++ b/src/keepass2android-app/keepass2android-app.csproj
@@ -743,14 +743,22 @@
     <AndroidNativeLibrary Include="..\java\argon2\libs\x86_64\libargon2.so" Link="x86_64\libargon2.so" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.5" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.2.3" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.Core" Version="1.4.2.3" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" />
+    <!-- Pin lifecycle transitive dep required by CameraX 1.4.x -->
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.9.2.1" />
+    <!-- Pin SavedState.Ktx to match the SavedState 1.3.1.1 pulled in by CameraX 1.4.x (avoids duplicate ViewKt class in D8) -->
+    <PackageReference Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.1.1" />
     <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.30" />
     <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.27" />
     <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout" Version="1.3.0" />
-    <PackageReference Include="Xamarin.AndroidX.CursorAdapter" Version="1.0.0.31" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.7.2" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.7.2" />
+    <PackageReference Include="Xamarin.AndroidX.CursorAdapter" Version="1.0.0.34" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.9.2.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.2.1" />
     <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.2.1.12" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.12.0.2" />
     <PackageReference Include="Xamarin.Google.Guava" Version="33.4.0.1" />


### PR DESCRIPTION
Adds the option to add images directly through CameraX, i.e. without any potential caches etc. Allows to scale the image to keep database size reasonable. Handles different image orientations properly.

closes #23