### PR TITLE
Restore activity stack after reopening 

### DIFF
--- a/src/keepass2android-app/EntryActivity.cs
+++ b/src/keepass2android-app/EntryActivity.cs
@@ -151,6 +151,16 @@ namespace keepass2android
 
     }
 
+    public static Intent GetLaunchIntent(Context ctx, Database db, PwEntry pw, int pos, AppTask appTask)
+    {
+      Intent i = new Intent(ctx, typeof(EntryActivity));
+      i.PutExtra(KeyEntry, new ElementAndDatabaseId(db, pw).FullId);
+      i.PutExtra(KeyRefreshPos, pos);
+      i.PutExtra(KeyEntryHistoryIndex, -1);
+      appTask.ToIntent(i);
+      return i;
+    }
+
     public static void Launch(Activity act, PwEntry pw, int pos, AppTask appTask, ActivityFlags? flags = null, int historyIndex = -1)
     {
       Intent i = new Intent(act, typeof(EntryActivity));
@@ -532,6 +542,8 @@ namespace keepass2android
       SetupEditButtons();
 
       App.Kp2a.LastOpenedEntry = new PwEntryOutput(Entry, App.Kp2a.CurrentDb);
+      if (_historyIndex < 0)
+        App.Kp2a.LastOpenedEntryFullIdForRestore = new ElementAndDatabaseId(App.Kp2a.CurrentDb, Entry).FullId;
 
       _pluginActionReceiver = new PluginActionReceiver(this);
       ContextCompat.RegisterReceiver(this, _pluginActionReceiver, new IntentFilter(Strings.ActionAddEntryAction), (int)ReceiverFlags.Exported);
@@ -986,6 +998,7 @@ namespace keepass2android
 
     public override void OnBackPressed()
     {
+      App.Kp2a.LastOpenedEntryFullIdForRestore = null;
       base.OnBackPressed();
       //OverridePendingTransition(Resource.Animation.anim_enter_back, Resource.Animation.anim_leave_back);
     }
@@ -1535,6 +1548,7 @@ namespace keepass2android
           //Currently the action bar only displays the home button when we come from a previous activity.
           //So we can simply Finish. See this page for information on how to do this in more general (future?) cases:
           //http://developer.android.com/training/implementing-navigation/ancestral.html
+          App.Kp2a.LastOpenedEntryFullIdForRestore = null;
           Finish();
           //OverridePendingTransition(Resource.Animation.anim_enter_back, Resource.Animation.anim_leave_back);
 
@@ -1637,6 +1651,7 @@ namespace keepass2android
 
     public void CloseAfterTaskComplete()
     {
+      App.Kp2a.LastOpenedEntryFullIdForRestore = null;
       //before closing, wait a little to get plugin updates
       int numPlugins = new PluginDatabase(this).GetPluginsWithAcceptedScope(Strings.ScopeCurrentEntry).Count();
       var timeToWait = TimeSpan.FromMilliseconds(500 * numPlugins);

--- a/src/keepass2android-app/GroupActivity.cs
+++ b/src/keepass2android-app/GroupActivity.cs
@@ -69,6 +69,19 @@ namespace keepass2android
       Launch(act, null, appTask, launchMode);
     }
 
+    public static Intent GetRootLaunchIntent(Context ctx, AppTask appTask)
+    {
+      return GetLaunchIntent(ctx, App.Kp2a.CurrentDb.Root, appTask);
+    }
+
+    public static Intent GetLaunchIntent(Context ctx, PwGroup g, AppTask appTask)
+    {
+      Intent i = new Intent(ctx, typeof(GroupActivity));
+      i.PutExtra(KeyEntry, g.Uuid.ToHexString());
+      appTask.ToIntent(i);
+      return i;
+    }
+
     public static void Launch(Activity act, PwGroup g, AppTask appTask, ActivityLaunchMode launchMode)
     {
       Intent i = new Intent(act, typeof(GroupActivity));

--- a/src/keepass2android-app/SelectCurrentDbActivity.cs
+++ b/src/keepass2android-app/SelectCurrentDbActivity.cs
@@ -224,7 +224,7 @@ namespace keepass2android
     {
       App.Kp2a.CurrentDb = selectedDatabase;
       LaunchingOther = true;
-      AppTask.LaunchFirstGroupActivity(this);
+      GetEffectiveTask().LaunchFirstGroupActivity(this);
     }
 
     public override bool OnCreateOptionsMenu(IMenu menu)
@@ -300,7 +300,7 @@ namespace keepass2android
           {
             LaunchingOther = true;
             AppTask.CanActivateSearchViewOnStart = true;
-            AppTask.LaunchFirstGroupActivity(this);
+            GetEffectiveTask().LaunchFirstGroupActivity(this);
           }
         }
         else
@@ -436,7 +436,7 @@ namespace keepass2android
         if (OpenAutoExecEntries(App.Kp2a.CurrentDb)) return false;
         LaunchingOther = true;
         AppTask.CanActivateSearchViewOnStart = true;
-        AppTask.LaunchFirstGroupActivity(this);
+        GetEffectiveTask().LaunchFirstGroupActivity(this);
       }
       else
       {
@@ -448,6 +448,13 @@ namespace keepass2android
 
 
       return true;
+    }
+
+    private AppTask GetEffectiveTask()
+    {
+      if (AppTask is NullTask && !string.IsNullOrEmpty(App.Kp2a.LastOpenedEntryFullIdForRestore))
+        return new OpenLastEntryTask(App.Kp2a.LastOpenedEntryFullIdForRestore);
+      return AppTask;
     }
 
     protected override void OnResume()
@@ -493,7 +500,7 @@ namespace keepass2android
         if ((App.Kp2a.OpenDatabases.Count() == 1) || (AppTask is SearchUrlTask))
         {
           LaunchingOther = true;
-          AppTask.LaunchFirstGroupActivity(this);
+          GetEffectiveTask().LaunchFirstGroupActivity(this);
           return;
         }
 
@@ -649,7 +656,7 @@ namespace keepass2android
 
               _pendingBackgroundSyncs.Clear();
 
-              AppTask.LaunchFirstGroupActivity(this);
+              GetEffectiveTask().LaunchFirstGroupActivity(this);
             }
 
 

--- a/src/keepass2android-app/app/App.cs
+++ b/src/keepass2android-app/app/App.cs
@@ -138,6 +138,8 @@ namespace keepass2android
             Kp2aLog.Log("QuickLocking database");
             QuickLocked = true;
             LastOpenedEntry = null;
+            if (!lockWasTriggeredByTimeout)
+              LastOpenedEntryFullIdForRestore = null;
             BroadcastDatabaseAction(LocaleManager.LocalizedAppContext, Strings.ActionLockDatabase);
           }
           else
@@ -157,6 +159,7 @@ namespace keepass2android
 
           _currentDatabase = null;
           LastOpenedEntry = null;
+          LastOpenedEntryFullIdForRestore = null;
           QuickLocked = false;
 
 
@@ -480,6 +483,13 @@ namespace keepass2android
     /// Information about the last opened entry. Includes the entry but also transformed fields.
     /// </summary>
     public PwEntryOutput LastOpenedEntry { get; set; }
+
+    /// <summary>
+    /// FullId of the last entry opened in EntryActivity that should be restored after a
+    /// timeout-triggered QuickLock/unlock cycle. Cleared when the user explicitly navigates
+    /// away from the entry (back, Home, CloseAfterTaskComplete) or explicitly locks the database.
+    /// </summary>
+    public string? LastOpenedEntryFullIdForRestore { get; set; }
 
     public Database CurrentDb
     {

--- a/src/keepass2android-app/app/AppTask.cs
+++ b/src/keepass2android-app/app/AppTask.cs
@@ -1081,6 +1081,93 @@ namespace keepass2android
     }
   }
 
+  /// <summary>
+  /// Restores the full activity back stack (parent groups + EntryActivity) for
+  /// the last entry that was on screen when the database was locked by timeout.
+  /// Falls back silently to the root group if anything goes wrong.
+  /// </summary>
+  public class OpenLastEntryTask : AppTask
+  {
+    private readonly string _entryFullId;
+
+    public OpenLastEntryTask(string entryFullId)
+    {
+      _entryFullId = entryFullId;
+    }
+
+    public override void LaunchFirstGroupActivity(Activity act)
+    {
+      try
+      {
+        if (string.IsNullOrEmpty(_entryFullId))
+        {
+          FallBack(act);
+          return;
+        }
+
+        var fullId = new ElementAndDatabaseId(_entryFullId);
+        var db = App.Kp2a.GetDatabase(fullId.DatabaseId);
+        if (db == null)
+        {
+          FallBack(act);
+          return;
+        }
+
+        var uuid = new PwUuid(MemUtil.HexStringToByteArray(fullId.ElementIdString));
+        if (!db.EntriesById.ContainsKey(uuid))
+        {
+          FallBack(act);
+          return;
+        }
+
+        var entry = db.EntriesById[uuid];
+
+        // Build group chain from root down to the entry's immediate parent.
+        var groupChain = new System.Collections.Generic.List<PwGroup>();
+        var current = entry.ParentGroup;
+        while (current != null)
+        {
+          groupChain.Insert(0, current);
+          current = current.ParentGroup;
+        }
+
+        // Verify every group still exists in the database (handles moved/deleted entries).
+        foreach (var g in groupChain)
+        {
+          if (!db.GroupsById.ContainsKey(g.Uuid))
+          {
+            FallBack(act);
+            return;
+          }
+        }
+
+        if (App.Kp2a.CurrentDb != db)
+          App.Kp2a.CurrentDb = db;
+
+        var nullTask = new NullTask();
+        var stackBuilder = AndroidX.Core.App.TaskStackBuilder.Create(act);
+
+        foreach (var group in groupChain)
+          stackBuilder.AddNextIntent(GroupActivity.GetLaunchIntent(act, group, nullTask));
+
+        stackBuilder.AddNextIntent(EntryActivity.GetLaunchIntent(act, db, entry, 0, nullTask));
+
+        stackBuilder.StartActivities();
+        act.Finish();
+      }
+      catch (Exception e)
+      {
+        Kp2aLog.LogUnexpectedError(e);
+        FallBack(act);
+      }
+    }
+
+    private static void FallBack(Activity act)
+    {
+      GroupActivity.Launch(act, new NullTask(), new ActivityLaunchModeRequestCode(0));
+    }
+  }
+
   public class NavigateToFolder : NavigateAndLaunchTask
   {
 
@@ -1095,6 +1182,106 @@ namespace keepass2android
     {
     }
 
+  }
+
+  /// <summary>
+  /// When reached in a group activity, opens a specific entry by its FullId.
+  /// Used as the inner task of NavigateAndOpenEntryTask.
+  /// </summary>
+  public class OpenEntryTask : AppTask
+  {
+    public const string EntryFullIdKey = "OpenEntryFullId";
+    public string EntryFullId { get; set; }
+
+    public override void Setup(Bundle b)
+    {
+      base.Setup(b);
+      EntryFullId = b.GetString(EntryFullIdKey);
+    }
+
+    public override IEnumerable<IExtra> Extras
+    {
+      get
+      {
+        foreach (var e in base.Extras) yield return e;
+        if (EntryFullId != null)
+          yield return new StringExtra { Key = EntryFullIdKey, Value = EntryFullId };
+      }
+    }
+
+    public override void StartInGroupActivity(GroupBaseActivity groupBaseActivity)
+    {
+      if (string.IsNullOrEmpty(EntryFullId)) return;
+      try
+      {
+        var id = new ElementAndDatabaseId(EntryFullId);
+        var uuid = new PwUuid(MemUtil.HexStringToByteArray(id.ElementIdString));
+        var db = App.Kp2a.CurrentDb;
+        if (db == null || !db.EntriesById.ContainsKey(uuid)) return;
+        groupBaseActivity.LaunchActivityForEntry(db.EntriesById[uuid], 0);
+      }
+      catch (Exception e)
+      {
+        Kp2aLog.LogUnexpectedError(e);
+      }
+    }
+  }
+
+  /// <summary>
+  /// Navigates through the group hierarchy to the parent of a specific entry,
+  /// then opens that entry.
+  /// </summary>
+  public class NavigateAndOpenEntryTask : NavigateAndLaunchTask
+  {
+    public NavigateAndOpenEntryTask()
+    {
+    }
+
+    public NavigateAndOpenEntryTask(PwGroup targetGroup, string entryFullId)
+        : base(targetGroup, new OpenEntryTask { EntryFullId = entryFullId })
+    {
+    }
+
+    public override void Setup(Bundle b)
+    {
+      base.Setup(b);
+      TaskToBeLaunchedAfterNavigation = new OpenEntryTask();
+      TaskToBeLaunchedAfterNavigation.Setup(b);
+    }
+  }
+
+  /// <summary>
+  /// Restores the last opened entry (from App.Kp2a.LastOpenedEntryFullIdForRestore)
+  /// by navigating through the group hierarchy and reopening the entry.
+  /// Falls back to the root group if the entry or its parent groups can no longer be found.
+  /// </summary>
+  public class RestoreLastEntryTask : AppTask
+  {
+    public override void LaunchFirstGroupActivity(Activity act)
+    {
+      try
+      {
+        string fullId = App.Kp2a.LastOpenedEntryFullIdForRestore;
+        if (string.IsNullOrEmpty(fullId)) { new NullTask().LaunchFirstGroupActivity(act); return; }
+
+        var id = new ElementAndDatabaseId(fullId);
+        var db = App.Kp2a.GetDatabase(id.DatabaseId);
+        if (db == null) { new NullTask().LaunchFirstGroupActivity(act); return; }
+
+        var uuid = new PwUuid(MemUtil.HexStringToByteArray(id.ElementIdString));
+        if (!db.EntriesById.ContainsKey(uuid)) { new NullTask().LaunchFirstGroupActivity(act); return; }
+
+        var entry = db.EntriesById[uuid];
+        if (entry.ParentGroup == null) { new NullTask().LaunchFirstGroupActivity(act); return; }
+
+        new NavigateAndOpenEntryTask(entry.ParentGroup, fullId).LaunchFirstGroupActivity(act);
+      }
+      catch (Exception e)
+      {
+        Kp2aLog.LogUnexpectedError(e);
+        new NullTask().LaunchFirstGroupActivity(act);
+      }
+    }
   }
 
   public class NavigateToFolderAndLaunchMoveElementTask : NavigateAndLaunchTask


### PR DESCRIPTION
If the app is closed by timeout, we want to restore the activity stack (e.g. show the last opened entry) after re-opening.

closes #58 